### PR TITLE
Prevent horizontal scroll in the main content causing top bar motion

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -128,7 +128,9 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     );
     return NotificationListener<ScrollNotification>(
       onNotification: (scrollNotification) {
-        if (scrollNotification is ScrollUpdateNotification) {
+        final isVerticalScrollNotification = scrollNotification is ScrollUpdateNotification &&
+            scrollNotification.metrics.axis == Axis.vertical;
+        if (isVerticalScrollNotification) {
           widget.currentScrollPosition.value = scrollNotification.metrics.pixels;
         }
         return false;

--- a/playground/lib/home/pages/sheet_page_with_lazy_list.dart
+++ b/playground/lib/home/pages/sheet_page_with_lazy_list.dart
@@ -39,9 +39,31 @@ class SheetPageWithLazyList {
       closeButton: WoltModalSheetCloseButton(onClosed: onClosed),
       sliverList: SliverList(
         delegate: SliverChildBuilderDelegate(
-          (_, index) => ColorTile(color: colors[index]),
-          childCount: colors.length,
+          (_, index) {
+            if (index == 0) {
+              return const _HorizontalPrimaryColorList();
+            }
+            return ColorTile(color: colors[index]);
+          },
+          childCount: colors.length + 1,
         ),
+      ),
+    );
+  }
+}
+
+class _HorizontalPrimaryColorList extends StatelessWidget {
+  const _HorizontalPrimaryColorList();
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      physics: const BouncingScrollPhysics(),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (Color color in Colors.primaries) Container(color: color, height: 100, width: 33),
+        ],
       ),
     );
   }

--- a/playground_navigator2/lib/modal/pages/sheet_page_with_lazy_list.dart
+++ b/playground_navigator2/lib/modal/pages/sheet_page_with_lazy_list.dart
@@ -41,9 +41,31 @@ class SheetPageWithLazyList {
       closeButton: WoltModalSheetCloseButton(onClosed: cubit.closeSheet),
       sliverList: SliverList(
         delegate: SliverChildBuilderDelegate(
-          (_, index) => ColorTile(color: colors[index]),
-          childCount: colors.length,
+              (_, index) {
+            if (index == 0) {
+              return const _HorizontalPrimaryColorList();
+            }
+            return ColorTile(color: colors[index]);
+          },
+          childCount: colors.length + 1,
         ),
+      ),
+    );
+  }
+}
+
+class _HorizontalPrimaryColorList extends StatelessWidget {
+  const _HorizontalPrimaryColorList();
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      physics: const BouncingScrollPhysics(),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          for (Color color in Colors.primaries) Container(color: color, height: 100, width: 33),
+        ],
       ),
     );
   }


### PR DESCRIPTION
This PR prevents the Top bar motion caused by horizontal scrolling.

Reported in Issue #10 

| Before  | After |
| ------------- | ------------- |
|  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/83c67173-7fe9-4012-b9c4-28bd01ab3338"> | <video src=https://github.com/woltapp/wolt_modal_sheet/assets/13782003/8d041403-0723-4f45-9ffd-b317631ce727> |