### PR TITLE
Add callback for on modal dismiss with drag to be utilized in Navigator 2.0

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -23,6 +23,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     required this.pageListBuilderNotifier,
     required this.pageIndexNotifier,
     required this.onModalDismissedWithBarrierTap,
+    required this.onModalDismissedWithDrag,
     required this.decorator,
     required this.modalTypeBuilder,
     required this.animationController,
@@ -39,6 +40,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   final ValueNotifier<WoltModalSheetPageListBuilder> pageListBuilderNotifier;
   final ValueNotifier<int> pageIndexNotifier;
   final VoidCallback? onModalDismissedWithBarrierTap;
+  final VoidCallback? onModalDismissedWithDrag;
   final Widget Function(Widget)? decorator;
   final WoltModalType Function(BuildContext context) modalTypeBuilder;
   final AnimationController? animationController;
@@ -68,6 +70,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     RouteSettings? routeSettings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
+    VoidCallback? onModalDismissedWithDrag,
     AnimationController? transitionAnimationController,
     AnimatedWidget? bottomSheetTransitionAnimation,
     AnimatedWidget? dialogTransitionAnimation,
@@ -112,6 +115,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     RouteSettings? routeSettings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
+    VoidCallback? onModalDismissedWithDrag,
     AnimationController? transitionAnimationController,
     AnimatedWidget? bottomSheetTransitionAnimation,
     AnimatedWidget? dialogTransitionAnimation,
@@ -133,6 +137,7 @@ class WoltModalSheet<T> extends StatefulWidget {
         barrierDismissible: barrierDismissible,
         enableDragForBottomSheet: enableDragForBottomSheet,
         onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
+        onModalDismissedWithDrag: onModalDismissedWithDrag,
         transitionAnimationController: transitionAnimationController,
         useSafeArea: useSafeArea,
         bottomSheetTransitionAnimation: bottomSheetTransitionAnimation,
@@ -220,10 +225,7 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                     id: barrierLayoutId,
                     child: GestureDetector(
                       behavior: HitTestBehavior.opaque,
-                      onTap: () {
-                        widget.onModalDismissedWithBarrierTap?.call();
-                        Navigator.of(context).pop();
-                      },
+                      onTap: widget.onModalDismissedWithBarrierTap ?? Navigator.of(context).pop,
                       child: const SizedBox.expand(),
                     ),
                   ),
@@ -331,7 +333,12 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
     );
 
     if (isClosing && widget.route.isCurrent) {
-      Navigator.pop(context);
+      final onModalDismissedWithDrag = widget.onModalDismissedWithDrag;
+      if (onModalDismissedWithDrag != null) {
+        onModalDismissedWithDrag();
+      } else {
+        Navigator.pop(context);
+      }
     }
   }
 }

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -8,6 +8,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     this.pageIndexNotifier,
     this.decorator,
     this.onModalDismissedWithBarrierTap,
+    this.onModalDismissedWithDrag,
     bool? enableDragForBottomSheet,
     bool? useSafeArea,
     bool? barrierDismissible,
@@ -46,6 +47,8 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
   late final bool _barrierDismissible;
 
   final VoidCallback? onModalDismissedWithBarrierTap;
+
+  final VoidCallback? onModalDismissedWithDrag;
 
   final bool _enableDragForBottomSheet;
 
@@ -100,6 +103,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
       pageListBuilderNotifier: pageListBuilderNotifier,
       modalTypeBuilder: modalTypeBuilder,
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
+      onModalDismissedWithDrag: onModalDismissedWithDrag,
       animationController: animationController,
       enableDragForBottomSheet: _enableDragForBottomSheet,
       useSafeArea: _useSafeArea,

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -82,7 +82,16 @@ class _HomeScreenState extends State<HomeScreen> {
                   context: context,
                   pageListBuilderNotifier: pageListBuilderNotifier,
                   modalTypeBuilder: _modalTypeBuilder,
-                  onModalDismissedWithBarrierTap: () => pageIndexNotifier.value = 0,
+                  onModalDismissedWithDrag: () {
+                    debugPrint('Bottom sheet is dismissed with drag.');
+                    Navigator.of(context).pop();
+                    pageIndexNotifier.value = 0;
+                  },
+                  onModalDismissedWithBarrierTap: () {
+                    debugPrint('Modal is dismissed with barrier tap.');
+                    Navigator.of(context).pop();
+                    pageIndexNotifier.value = 0;
+                  },
                   maxDialogWidth: 560,
                   minDialogWidth: 400,
                   minPageHeight: 0.4,

--- a/playground_navigator2/lib/router/playground_router_delegate.dart
+++ b/playground_navigator2/lib/router/playground_router_delegate.dart
@@ -66,9 +66,6 @@ class PlaygroundRouterDelegate extends RouterDelegate<PlaygroundRouterConfigurat
       pages: pages,
       onPopPage: (route, result) {
         if (!route.didPop(result)) return false;
-        if (route.settings.name == SheetPage.routeName) {
-          _cubit.closeSheet();
-        }
         return true;
       },
     );

--- a/playground_navigator2/lib/router/router_pages/sheet_page.dart
+++ b/playground_navigator2/lib/router/router_pages/sheet_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:playground_navigator2/bloc/router_cubit.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class SheetPage extends Page<void> {
@@ -21,6 +23,12 @@ class SheetPage extends Page<void> {
       pageIndexNotifier: pageIndexNotifier,
       modalTypeBuilder: modalTypeBuilder,
       pageListBuilderNotifier: pageListBuilderNotifier,
+      onModalDismissedWithDrag: () {
+        context.read<RouterCubit>().closeSheet();
+      },
+      onModalDismissedWithBarrierTap: () {
+        context.read<RouterCubit>().closeSheet();
+      },
       routeSettings: this,
     );
   }


### PR DESCRIPTION
This PR adds `onModalDismissedWithDrag` field to the `WoltModalSheetRoute` to detect the modal dismiss with drag gesture.

When using imperative API, it is enough to call `Navigator.of(context).pop()` to dismiss the modal. In fact, this is the default behavior when dismiss callbacks are not provided by the library users. However, using Navigator 2.0 requires actions in the callbacks to update the app state that builds the navigation stack on modal dismiss events.

In this screen recording from navigator2 playground example, it can be seen that the address bar is updated with both barrier tap and dismiss by frag events.

Note that earlier, this was handled in router delegate with Navigator's `onPop` callback. We no longer need to handle this imperatively in the Navigator widget.

 <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/32139c96-a633-4bd0-a4cd-91b7fc9120b9">