### PR TITLE
Rename page list builder notifier parameter for WoltModalSheet.show method

### DIFF
--- a/coffee_maker/lib/home/online/store_online_content.dart
+++ b/coffee_maker/lib/home/online/store_online_content.dart
@@ -87,7 +87,7 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
     WoltModalSheet.show(
       pageIndexNotifier: pageIndexNotifier,
       context: context,
-      pageListBuilderNotifier: GrindModalPageBuilder.build(
+      pageListBuilder: GrindModalPageBuilder.build(
         coffeeOrderId: coffeeOrderId,
         goToPreviousPage: () => pageIndexNotifier.value = pageIndexNotifier.value - 1,
         goToNextPage: () => pageIndexNotifier.value = pageIndexNotifier.value + 1,
@@ -117,7 +117,7 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
           builder: (_, __) => child,
         );
       },
-      pageListBuilderNotifier: AddWaterModalPageBuilder.build(
+      pageListBuilder: AddWaterModalPageBuilder.build(
         coffeeOrderId: coffeeOrderId,
         goToPreviousPage: () => pageIndexNotifier.value = pageIndexNotifier.value - 1,
         goToNextPage: () => pageIndexNotifier.value = pageIndexNotifier.value + 1,
@@ -133,7 +133,7 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
     WoltModalSheet.show(
       pageIndexNotifier: pageIndexNotifier,
       context: context,
-      pageListBuilderNotifier: ReadyModalPageBuilder.build(
+      pageListBuilder: ReadyModalPageBuilder.build(
         coffeeOrderId: coffeeOrderId,
         goToPreviousPage: () => pageIndexNotifier.value = pageIndexNotifier.value - 1,
         goToNextPage: () => pageIndexNotifier.value = pageIndexNotifier.value + 1,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -104,7 +104,7 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
                     WoltModalSheet.show<void>(
                       pageIndexNotifier: pageIndexNotifier,
                       context: context,
-                      pageListBuilderNotifier: (modalSheetContext) {
+                      pageListBuilder: (modalSheetContext) {
                         return [
                           page1(modalSheetContext),
                           page2(modalSheetContext),

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -57,7 +57,7 @@ class WoltModalSheet<T> extends StatefulWidget {
 
   static Future<T?> show<T>({
     required BuildContext context,
-    required WoltModalSheetPageListBuilder pageListBuilderNotifier,
+    required WoltModalSheetPageListBuilder pageListBuilder,
     required WoltModalTypeBuilder modalTypeBuilder,
     ValueNotifier<int>? pageIndexNotifier,
     Widget Function(Widget)? decorator,
@@ -78,7 +78,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   }) {
     return WoltModalSheet.showWithDynamicPath(
       context: context,
-      pageListBuilderNotifier: ValueNotifier(pageListBuilderNotifier),
+      pageListBuilderNotifier: ValueNotifier(pageListBuilder),
       modalTypeBuilder: modalTypeBuilder,
       pageIndexNotifier: pageIndexNotifier,
       decorator: decorator,


### PR DESCRIPTION
`WoltModalSheet.show` method is a shortcut when the users of the library do not need a dynamically set page list builder. This is why we don't need a `ValueNotifier` for this method. This PR removes the `notifier` suffix to match this.