### PR TITLE
Scale image from center in HeroImageFlowDelegate

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_hero_image.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_hero_image.dart
@@ -85,7 +85,7 @@ class _HeroImageFlowDelegate extends FlowDelegate {
   void paintChildren(FlowPaintingContext flowPaintingContext) {
     final currentScrollPosition = scrollPosition.pixels;
 
-    /// Calculate the scale
+    // Calculate scale
     final double scale = WoltLayoutTransformationUtils.calculateTransformationValue(
       startValue: 1.1,
       endValue: 1.0,
@@ -93,17 +93,28 @@ class _HeroImageFlowDelegate extends FlowDelegate {
       progressInRangeInPx: currentScrollPosition,
     );
 
-    /// Calculate the opacity
+    // Calculate opacity
     final double opacity = WoltLayoutTransformationUtils.calculateTransformationValue(
       rangeInPx: heroImageHeight / 2,
-      progressInRangeInPx: currentScrollPosition - ((heroImageHeight - topBarHeight) / 2),
+      progressInRangeInPx: currentScrollPosition - ((heroImageHeight / 2) - topBarHeight),
       startValue: 1.0,
       endValue: 0.0,
     );
 
+    // Calculate the translation to center the image
+    final double translationX = (flowPaintingContext.size.width -
+            (flowPaintingContext.getChildSize(0)?.width ?? 0) * scale) /
+        2;
+    final double translationY = (flowPaintingContext.size.height -
+            (flowPaintingContext.getChildSize(0)?.height ?? 0) * scale) /
+        2;
+    // Create the transformation matrix
+    final Matrix4 transformMatrix = Matrix4.identity()
+      ..scale(scale, scale)
+      ..translate(translationX, translationY);
     flowPaintingContext.paintChild(
       0,
-      transform: Matrix4.diagonal3Values(scale, scale, 1.0),
+      transform: transformMatrix,
       opacity: opacity,
     );
   }


### PR DESCRIPTION
## Description
This PR modifies the `_HeroImageFlowDelegate` class to scale the image from the center instead of the top left corner.

## Problem
The hero image was scaling from the top left corner and this was causing the image to look not-centered.
To fix this, we now scale the image from the center.

In the updated code, we calculate the `translationX` and `translationY` values to shift the image by half of the difference between the container size and the scaled image size. Then, we create a `Matrix4` object using `Matrix4.identity()` and apply both the scaling and translation using the `scale` and `translate` methods respectively. Finally, we pass the resulting `transformMatrix` to the `transform` property of `flowPaintingContext.paintChild`.
With this modification, the image should be scaled from the center instead of the top left.

## Screenshots
### Phone
| Before | After |
| - | - |
| <img width=300 src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/f7c2b709-5891-47b3-8b01-cc230e128aec> | <img width=300 src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/bcf28033-d3fe-48cf-bf94-0bf8a8ca3733> |

### Tablet
| Before | After |
| - | - |
| <img width=400 src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/88d9f631-e5cf-41d6-9612-d31c14a238c4> | <img width=400 src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/9a87069f-c0d5-4cb0-9e12-c458a563eced> |