### PR TITLE
Added missing onModalDismissedWithDrag parameter .show method

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -92,6 +92,7 @@ class WoltModalSheet<T> extends StatefulWidget {
       routeSettings: routeSettings,
       transitionDuration: transitionDuration,
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
+      onModalDismissedWithDrag: onModalDismissedWithDrag,
       transitionAnimationController: transitionAnimationController,
       bottomSheetTransitionAnimation: bottomSheetTransitionAnimation,
       dialogTransitionAnimation: dialogTransitionAnimation,


### PR DESCRIPTION
# Description

This PR corrects the missing parameter input in the .show method and enables the onModalDismissedWithDrag callback to work.