### PR TITLE
Rework the changelog to show the latest update at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-## 0.0.1
-
-- Initial version.
-
-## 0.0.2
-
-- Fix Readme
-
-## 0.0.3
-
-- Fix broken gifs in ReadMe [#3](https://github.com/woltapp/wolt_modal_sheet/pull/3)
-
 ## 0.0.4
 
 - Fix repository link in pubspec file [#5](https://github.com/woltapp/wolt_modal_sheet/pull/5)
@@ -18,3 +6,15 @@
 - Add callback for on modal dismiss with drag to be utilized in Navigator 2.0 [#15](https://github.com/woltapp/wolt_modal_sheet/pull/15)
 - Rename page list builder notifier parameter for WoltModalSheet.show method [#16](https://github.com/woltapp/wolt_modal_sheet/pull/16)
 - Scale hero image from center in HeroImageFlowDelegate [#17](https://github.com/woltapp/wolt_modal_sheet/pull/17)
+
+## 0.0.3
+
+- Fix broken gifs in ReadMe [#3](https://github.com/woltapp/wolt_modal_sheet/pull/3)
+
+## 0.0.2
+
+- Fix Readme
+
+## 0.0.1
+
+- Initial version.


### PR DESCRIPTION
A common practice is to show the latest update of a package/project at the top. Otherwise, when the are a bunch of updates already, users will need to scroll down to the bottom to see the latest changes.