### PR TITLE
Fix linter violations

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  wolt_modal_sheet:
+    path: ..
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  wolt_modal_sheet:
-    path: ..
 
 flutter:
   uses-material-design: true

--- a/lib/src/content/components/main_content/wolt_modal_sheet_top_bar.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_top_bar.dart
@@ -1,7 +1,4 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:wolt_modal_sheet/src/modal_page/wolt_modal_sheet_page.dart';
-import 'package:wolt_modal_sheet/src/utils/wolt_layout_transformation_utils.dart';
 
 class WoltModalSheetTopBar extends StatelessWidget {
   /// The height of the top bar, defined by the user.

--- a/playground_navigator2/lib/router/playground_router_delegate.dart
+++ b/playground_navigator2/lib/router/playground_router_delegate.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 
-import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:playground_navigator2/bloc/router_state.dart';
 import 'package:playground_navigator2/bloc/router_cubit.dart';
+import 'package:playground_navigator2/bloc/router_state.dart';
 import 'package:playground_navigator2/router/playground_router_configuration.dart';
 import 'package:playground_navigator2/router/router_pages/home_page.dart';
 import 'package:playground_navigator2/router/router_pages/sheet_page.dart';
 import 'package:playground_navigator2/router/router_pages/unknown_page.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
-import 'package:wolt_responsive_layout_grid/wolt_responsive_layout_grid.dart';
 
 class PlaygroundRouterDelegate extends RouterDelegate<PlaygroundRouterConfiguration>
     with ChangeNotifier, PopNavigatorRouterDelegateMixin<PlaygroundRouterConfiguration> {


### PR DESCRIPTION
Fixes the following linting warnings:

```shell
   info • The imported package 'wolt_modal_sheet' isn't a dependency of the importing package • example/lib/main.dart:2:8 • depend_on_referenced_packages
   info • The import of 'package:flutter/foundation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' •
          lib/src/content/components/main_content/wolt_modal_sheet_top_bar.dart:1:8 • unnecessary_import
warning • Unused import: 'package:wolt_modal_sheet/src/modal_page/wolt_modal_sheet_page.dart' • lib/src/content/components/main_content/wolt_modal_sheet_top_bar.dart:3:8 • unused_import
warning • Unused import: 'package:wolt_modal_sheet/src/utils/wolt_layout_transformation_utils.dart' • lib/src/content/components/main_content/wolt_modal_sheet_top_bar.dart:4:8 • unused_import
warning • Unused import: 'package:demo_ui_components/demo_ui_components.dart' • playground_navigator2/lib/router/playground_router_delegate.dart:3:8 • unused_import
   info • The imported package 'wolt_responsive_layout_grid' isn't a dependency of the importing package • playground_navigator2/lib/router/playground_router_delegate.dart:12:8 •
          depend_on_referenced_packages
warning • Unused import: 'package:wolt_responsive_layout_grid/wolt_responsive_layout_grid.dart' • playground_navigator2/lib/router/playground_router_delegate.dart:12:8 • unused_import
```
