### PR TITLE
Prevent the scroll offset from reaching beyond the bounds of the content in main scroll view

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -67,6 +67,7 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     final heroImageHeight = widget.page.heroImageHeight ?? 0;
     final scrollView = CustomScrollView(
       shrinkWrap: true,
+      physics: const ClampingScrollPhysics(),
       controller: scrollController,
       slivers: [
         SliverPadding(


### PR DESCRIPTION
This PR changes the scroll physics so that the scroll offset is prevented from reaching beyond the bounds of the content in main scroll view
| Before  | After |
| ------------- | ------------- |
|  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/fb9a6ecd-97ab-4fe7-bc03-08f43399d675"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/60823a83-9a45-44f8-8ba4-f515c4bbaf89"> |