### PR TITLE
Add option to dynamically enable bottom sheet drag for a single page

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -18,14 +18,14 @@ class WoltModalSheetAnimatedSwitcher extends StatefulWidget {
   final int pageIndex;
   final WoltModalType woltModalType;
   final double sheetWidth;
-  final bool showDragHandleForBottomSheet;
+  final bool showDragHandle;
 
   const WoltModalSheetAnimatedSwitcher({
     required this.pages,
     required this.pageIndex,
     required this.woltModalType,
     required this.sheetWidth,
-    required this.showDragHandleForBottomSheet,
+    required this.showDragHandle,
     Key? key,
   })  : assert(pageIndex >= 0 && pageIndex < pages.length),
         super(key: key);
@@ -127,7 +127,7 @@ class _WoltModalSheetAnimatedSwitcherState extends State<WoltModalSheetAnimatedS
             page: _page,
             woltModalType: widget.woltModalType,
             topBarTranslationY: _topBarTranslationY,
-            showDragHandleForBottomSheet: widget.showDragHandleForBottomSheet,
+            showDragHandle: widget.showDragHandle,
           ),
         if (currentWidgets != null)
           WoltModalSheetLayout(
@@ -135,7 +135,7 @@ class _WoltModalSheetAnimatedSwitcherState extends State<WoltModalSheetAnimatedS
             page: _page,
             woltModalType: widget.woltModalType,
             topBarTranslationY: _topBarTranslationY,
-            showDragHandleForBottomSheet: widget.showDragHandleForBottomSheet,
+            showDragHandle: widget.showDragHandle,
           ),
         if (currentWidgets != null &&
             animationController != null &&

--- a/lib/src/content/wolt_modal_sheet_layout.dart
+++ b/lib/src/content/wolt_modal_sheet_layout.dart
@@ -12,7 +12,7 @@ class WoltModalSheetLayout extends StatelessWidget {
     required this.paginatingWidgetsGroup,
     required this.woltModalType,
     required this.topBarTranslationY,
-    required this.showDragHandleForBottomSheet,
+    required this.showDragHandle,
     Key? key,
   }) : super(key: key);
 
@@ -20,7 +20,7 @@ class WoltModalSheetLayout extends StatelessWidget {
   final PaginatingWidgetsGroup paginatingWidgetsGroup;
   final WoltModalType woltModalType;
   final double topBarTranslationY;
-  final bool showDragHandleForBottomSheet;
+  final bool showDragHandle;
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +44,7 @@ class WoltModalSheetLayout extends StatelessWidget {
               height: topBarHeight,
               child: paginatingWidgetsGroup.topBarAnimatedBuilder,
             ),
-          if (showDragHandleForBottomSheet)
+          if (showDragHandle)
             const Positioned(
               left: 0,
               right: 0,

--- a/lib/src/modal_page/wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/wolt_modal_sheet_page.dart
@@ -120,7 +120,7 @@ class WoltModalSheetPage {
 
   /// Controls the draggability of the bottom sheet. This setting overrides the value provided
   /// via [WoltModalSheet.show] specifically for this page when the modal is displayed as a bottom sheet.
-  final bool? enableDragForBottomSheet;
+  final bool? enableDrag;
 
   /// The color of the gentle gradient overlay that is rendered above the [stickyActionBar]. The
   /// purpose of this gradient is to visually suggest to the user that additional content might
@@ -150,7 +150,7 @@ class WoltModalSheetPage {
     this.heroImageHeight,
     this.backgroundColor,
     this.hasSabGradient,
-    this.enableDragForBottomSheet,
+    this.enableDrag,
     this.sabGradientColor,
     this.forceMaxHeight = false,
     this.scrollController,
@@ -172,7 +172,7 @@ class WoltModalSheetPage {
     Color? backgroundColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool forceMaxHeight = false,
     bool? isTopBarLayerAlwaysVisible,
     bool? hasTopBarLayer,
@@ -190,7 +190,7 @@ class WoltModalSheetPage {
       heroImageHeight: heroImageHeight,
       backgroundColor: backgroundColor,
       hasSabGradient: hasSabGradient,
-      enableDragForBottomSheet: enableDragForBottomSheet,
+      enableDrag: enableDrag,
       sabGradientColor: sabGradientColor,
       forceMaxHeight: forceMaxHeight,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
@@ -213,7 +213,7 @@ class WoltModalSheetPage {
     Color? backgroundColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool forceMaxHeight = false,
     bool? isTopBarLayerAlwaysVisible,
     bool? hasTopBarLayer,
@@ -232,7 +232,7 @@ class WoltModalSheetPage {
       backgroundColor: backgroundColor,
       hasSabGradient: hasSabGradient,
       sabGradientColor: sabGradientColor,
-      enableDragForBottomSheet: enableDragForBottomSheet,
+      enableDrag: enableDrag,
       forceMaxHeight: forceMaxHeight,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
       hasTopBarLayer: hasTopBarLayer,
@@ -254,7 +254,7 @@ class WoltModalSheetPage {
     Color? backgroundColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool? forceMaxHeight,
     bool? isTopBarLayerAlwaysVisible,
     bool? hasTopBarLayer,
@@ -274,7 +274,7 @@ class WoltModalSheetPage {
       backgroundColor: backgroundColor ?? this.backgroundColor,
       hasSabGradient: hasSabGradient ?? this.hasSabGradient,
       sabGradientColor: sabGradientColor ?? this.sabGradientColor,
-      enableDragForBottomSheet: enableDragForBottomSheet ?? this.enableDragForBottomSheet,
+      enableDrag: enableDrag ?? this.enableDrag,
       forceMaxHeight: forceMaxHeight ?? this.forceMaxHeight,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible ?? this.isTopBarLayerAlwaysVisible,
       hasTopBarLayer: hasTopBarLayer ?? this.hasTopBarLayer,

--- a/lib/src/modal_page/wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/wolt_modal_sheet_page.dart
@@ -118,6 +118,10 @@ class WoltModalSheetPage {
   /// `true`.
   final bool? hasSabGradient;
 
+  /// Controls the draggability of the bottom sheet. This setting overrides the value provided
+  /// via [WoltModalSheet.show] specifically for this page when the modal is displayed as a bottom sheet.
+  final bool? enableDragForBottomSheet;
+
   /// The color of the gentle gradient overlay that is rendered above the [stickyActionBar]. The
   /// purpose of this gradient is to visually suggest to the user that additional content might
   /// be present below the action bar.
@@ -146,6 +150,7 @@ class WoltModalSheetPage {
     this.heroImageHeight,
     this.backgroundColor,
     this.hasSabGradient,
+    this.enableDragForBottomSheet,
     this.sabGradientColor,
     this.forceMaxHeight = false,
     this.scrollController,
@@ -167,6 +172,7 @@ class WoltModalSheetPage {
     Color? backgroundColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
+    bool? enableDragForBottomSheet,
     bool forceMaxHeight = false,
     bool? isTopBarLayerAlwaysVisible,
     bool? hasTopBarLayer,
@@ -184,6 +190,7 @@ class WoltModalSheetPage {
       heroImageHeight: heroImageHeight,
       backgroundColor: backgroundColor,
       hasSabGradient: hasSabGradient,
+      enableDragForBottomSheet: enableDragForBottomSheet,
       sabGradientColor: sabGradientColor,
       forceMaxHeight: forceMaxHeight,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
@@ -206,6 +213,7 @@ class WoltModalSheetPage {
     Color? backgroundColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
+    bool? enableDragForBottomSheet,
     bool forceMaxHeight = false,
     bool? isTopBarLayerAlwaysVisible,
     bool? hasTopBarLayer,
@@ -224,6 +232,7 @@ class WoltModalSheetPage {
       backgroundColor: backgroundColor,
       hasSabGradient: hasSabGradient,
       sabGradientColor: sabGradientColor,
+      enableDragForBottomSheet: enableDragForBottomSheet,
       forceMaxHeight: forceMaxHeight,
       isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible,
       hasTopBarLayer: hasTopBarLayer,
@@ -231,6 +240,48 @@ class WoltModalSheetPage {
       stickyActionBar: stickyActionBar,
       leadingNavBarWidget: leadingNavBarWidget,
       trailingNavBarWidget: trailingNavBarWidget,
+    );
+  }
+
+  WoltModalSheetPage copyWith({
+    Widget? pageTitle,
+    double? navBarHeight,
+    Widget? sliverList,
+    Widget? singleChildContent,
+    Widget? topBarTitle,
+    Widget? heroImage,
+    double? heroImageHeight,
+    Color? backgroundColor,
+    bool? hasSabGradient,
+    Color? sabGradientColor,
+    bool? enableDragForBottomSheet,
+    bool? forceMaxHeight,
+    bool? isTopBarLayerAlwaysVisible,
+    bool? hasTopBarLayer,
+    ScrollController? scrollController,
+    Widget? stickyActionBar,
+    Widget? leadingNavBarWidget,
+    Widget? trailingNavBarWidget,
+  }) {
+    return WoltModalSheetPage(
+      pageTitle: pageTitle ?? this.pageTitle,
+      navBarHeight: navBarHeight ?? this.navBarHeight,
+      sliverList: sliverList ?? this.sliverList,
+      singleChildContent: singleChildContent ?? this.singleChildContent,
+      topBarTitle: topBarTitle ?? this.topBarTitle,
+      heroImage: heroImage ?? this.heroImage,
+      heroImageHeight: heroImageHeight ?? this.heroImageHeight,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      hasSabGradient: hasSabGradient ?? this.hasSabGradient,
+      sabGradientColor: sabGradientColor ?? this.sabGradientColor,
+      enableDragForBottomSheet: enableDragForBottomSheet ?? this.enableDragForBottomSheet,
+      forceMaxHeight: forceMaxHeight ?? this.forceMaxHeight,
+      isTopBarLayerAlwaysVisible: isTopBarLayerAlwaysVisible ?? this.isTopBarLayerAlwaysVisible,
+      hasTopBarLayer: hasTopBarLayer ?? this.hasTopBarLayer,
+      scrollController: scrollController ?? this.scrollController,
+      stickyActionBar: stickyActionBar ?? this.stickyActionBar,
+      leadingNavBarWidget: leadingNavBarWidget ?? this.leadingNavBarWidget,
+      trailingNavBarWidget: trailingNavBarWidget ?? this.trailingNavBarWidget,
     );
   }
 }

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -42,11 +42,11 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
 
   /// Whether to show the drag handle.
   @override
-  bool get showDragHandleForBottomSheet => enableDragForBottomSheet;
+  bool get showDragHandleForBottomSheet => enableDrag;
 
   /// Whether to enable the drag for bottom sheet.
   @override
-  bool get enableDragForBottomSheet => true;
+  bool get enableDrag => true;
 
   @override
   Color get dragHandleColor => _colors.onSurfaceVariant.withOpacity(0.4);

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -42,7 +42,7 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
 
   /// Whether to show the drag handle.
   @override
-  bool get showDragHandleForBottomSheet => enableDrag;
+  bool get showDragHandle => enableDrag;
 
   /// Whether to enable the drag for bottom sheet.
   @override

--- a/lib/src/theme/wolt_modal_sheet_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_theme_data.dart
@@ -14,7 +14,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     this.showDragHandleForBottomSheet,
     this.dragHandleColor,
     this.dragHandleSize,
-    this.enableDragForBottomSheet,
+    this.enableDrag,
     this.topBarShadowColor,
     this.topBarElevation,
     this.heroImageHeight,
@@ -65,7 +65,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
   final Size? dragHandleSize;
 
   /// Whether the bottom sheet can be dragged.
-  final bool? enableDragForBottomSheet;
+  final bool? enableDrag;
 
   /// The elevation color of the top bar.
   final Color? topBarShadowColor;

--- a/lib/src/theme/wolt_modal_sheet_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_theme_data.dart
@@ -11,7 +11,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     this.modalBarrierColor,
     this.bottomSheetShape,
     this.dialogShape,
-    this.showDragHandleForBottomSheet,
+    this.showDragHandle,
     this.dragHandleColor,
     this.dragHandleSize,
     this.enableDrag,
@@ -56,7 +56,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
   final ShapeBorder? dialogShape;
 
   /// Whether to show the drag handle.
-  final bool? showDragHandleForBottomSheet;
+  final bool? showDragHandle;
 
   /// The color of the drag handle.
   final Color? dragHandleColor;
@@ -135,7 +135,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     Color? modalBarrierColor,
     ShapeBorder? bottomSheetShape,
     ShapeBorder? dialogShape,
-    bool? showDragHandleForBottomSheet,
+    bool? showDragHandle,
     Color? dragHandleColor,
     Size? dragHandleSize,
     Color? topBarShadowColor,
@@ -160,7 +160,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
       modalBarrierColor: modalBarrierColor ?? this.modalBarrierColor,
       bottomSheetShape: bottomSheetShape ?? this.bottomSheetShape,
       dialogShape: dialogShape ?? this.dialogShape,
-      showDragHandleForBottomSheet: showDragHandleForBottomSheet ?? this.showDragHandleForBottomSheet,
+      showDragHandle: showDragHandle ?? this.showDragHandle,
       dragHandleColor: dragHandleColor ?? this.dragHandleColor,
       dragHandleSize: dragHandleSize ?? this.dragHandleSize,
       topBarShadowColor: topBarShadowColor ?? this.topBarShadowColor,
@@ -188,7 +188,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     return WoltModalSheetThemeData(
       backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t),
       modalElevation: lerpDouble(modalElevation, other.modalElevation, t),
-      showDragHandleForBottomSheet: t < 0.5 ? showDragHandleForBottomSheet : other.showDragHandleForBottomSheet,
+      showDragHandle: t < 0.5 ? showDragHandle : other.showDragHandle,
       modalBarrierColor: Color.lerp(modalBarrierColor, other.modalBarrierColor, t),
       bottomSheetShape: ShapeBorder.lerp(bottomSheetShape, other.bottomSheetShape, t),
       dialogShape: ShapeBorder.lerp(dialogShape, other.dialogShape, t),

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -29,7 +29,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     required this.modalTypeBuilder,
     required this.animationController,
     required this.route,
-    required this.enableDragForBottomSheet,
+    required this.enableDrag,
     required this.showDragHandleForBottomSheet,
     required this.useSafeArea,
     this.minDialogWidth,
@@ -47,7 +47,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   final WoltModalTypeBuilder modalTypeBuilder;
   final AnimationController? animationController;
   final WoltModalSheetRoute<T> route;
-  final bool? enableDragForBottomSheet;
+  final bool? enableDrag;
   final bool? showDragHandleForBottomSheet;
   final bool useSafeArea;
   final double? minDialogWidth;
@@ -69,7 +69,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool useRootNavigator = false,
     bool? useSafeArea,
     bool? barrierDismissible,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool? showDragHandleForBottomSheet,
     RouteSettings? routeSettings,
     Duration? transitionDuration,
@@ -93,7 +93,7 @@ class WoltModalSheet<T> extends StatefulWidget {
       useRootNavigator: useRootNavigator,
       useSafeArea: useSafeArea,
       barrierDismissible: barrierDismissible,
-      enableDragForBottomSheet: enableDragForBottomSheet,
+      enableDrag: enableDrag,
       showDragHandleForBottomSheet: showDragHandleForBottomSheet,
       routeSettings: routeSettings,
       transitionDuration: transitionDuration,
@@ -119,7 +119,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool useRootNavigator = false,
     bool? useSafeArea,
     bool? barrierDismissible,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool? showDragHandleForBottomSheet,
     RouteSettings? routeSettings,
     Duration? transitionDuration,
@@ -145,7 +145,7 @@ class WoltModalSheet<T> extends StatefulWidget {
         routeSettings: routeSettings,
         transitionDuration: transitionDuration,
         barrierDismissible: barrierDismissible,
-        enableDragForBottomSheet: enableDragForBottomSheet,
+        enableDrag: enableDrag,
         showDragHandleForBottomSheet: showDragHandleForBottomSheet,
         onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
         onModalDismissedWithDrag: onModalDismissedWithDrag,
@@ -229,10 +229,10 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                   break;
               }
               final enableDrag = _modalType == WoltModalType.bottomSheet &&
-                  (page.enableDragForBottomSheet ??
-                      widget.enableDragForBottomSheet ??
-                      themeData?.enableDragForBottomSheet ??
-                      defaultThemeData.enableDragForBottomSheet);
+                  (page.enableDrag ??
+                      widget.enableDrag ??
+                      themeData?.enableDrag ??
+                      defaultThemeData.enableDrag);
               final showDragHandle = widget.showDragHandleForBottomSheet ??
                   (enableDrag &&
                       (themeData?.showDragHandleForBottomSheet ??

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -30,7 +30,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     required this.animationController,
     required this.route,
     required this.enableDrag,
-    required this.showDragHandleForBottomSheet,
+    required this.showDragHandle,
     required this.useSafeArea,
     this.minDialogWidth,
     this.maxDialogWidth,
@@ -48,7 +48,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   final AnimationController? animationController;
   final WoltModalSheetRoute<T> route;
   final bool? enableDrag;
-  final bool? showDragHandleForBottomSheet;
+  final bool? showDragHandle;
   final bool useSafeArea;
   final double? minDialogWidth;
   final double? maxDialogWidth;
@@ -70,7 +70,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool? useSafeArea,
     bool? barrierDismissible,
     bool? enableDrag,
-    bool? showDragHandleForBottomSheet,
+    bool? showDragHandle,
     RouteSettings? routeSettings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
@@ -94,7 +94,7 @@ class WoltModalSheet<T> extends StatefulWidget {
       useSafeArea: useSafeArea,
       barrierDismissible: barrierDismissible,
       enableDrag: enableDrag,
-      showDragHandleForBottomSheet: showDragHandleForBottomSheet,
+      showDragHandle: showDragHandle,
       routeSettings: routeSettings,
       transitionDuration: transitionDuration,
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
@@ -120,7 +120,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool? useSafeArea,
     bool? barrierDismissible,
     bool? enableDrag,
-    bool? showDragHandleForBottomSheet,
+    bool? showDragHandle,
     RouteSettings? routeSettings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
@@ -146,7 +146,7 @@ class WoltModalSheet<T> extends StatefulWidget {
         transitionDuration: transitionDuration,
         barrierDismissible: barrierDismissible,
         enableDrag: enableDrag,
-        showDragHandleForBottomSheet: showDragHandleForBottomSheet,
+        showDragHandle: showDragHandle,
         onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
         onModalDismissedWithDrag: onModalDismissedWithDrag,
         transitionAnimationController: transitionAnimationController,
@@ -233,10 +233,10 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                       widget.enableDrag ??
                       themeData?.enableDrag ??
                       defaultThemeData.enableDrag);
-              final showDragHandle = widget.showDragHandleForBottomSheet ??
+              final showDragHandle = widget.showDragHandle ??
                   (enableDrag &&
-                      (themeData?.showDragHandleForBottomSheet ??
-                          defaultThemeData.showDragHandleForBottomSheet));
+                      (themeData?.showDragHandle ??
+                          defaultThemeData.showDragHandle));
               final pageBackgroundColor = page.backgroundColor ??
                   themeData?.backgroundColor ??
                   defaultThemeData.backgroundColor;
@@ -299,7 +299,7 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                                 pageIndex: pageIndex,
                                 pages: pages,
                                 sheetWidth: constraints.maxWidth,
-                                showDragHandleForBottomSheet: showDragHandle,
+                                showDragHandle: showDragHandle,
                               );
                             },
                           ),

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -229,7 +229,8 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                   break;
               }
               final enableDrag = _modalType == WoltModalType.bottomSheet &&
-                  (widget.enableDragForBottomSheet ??
+                  (page.enableDragForBottomSheet ??
+                      widget.enableDragForBottomSheet ??
                       themeData?.enableDragForBottomSheet ??
                       defaultThemeData.enableDragForBottomSheet);
               final showDragHandle = widget.showDragHandleForBottomSheet ??

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -19,7 +19,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     this.modalBarrierColor,
     WoltModalTypeBuilder? modalTypeBuilder,
     bool? enableDrag,
-    bool? showDragHandleForBottomSheet,
+    bool? showDragHandle,
     bool? useSafeArea,
     bool? barrierDismissible,
     AnimationController? transitionAnimationController,
@@ -32,7 +32,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     double? minPageHeight,
     double? maxPageHeight,
   })  : _enableDrag = enableDrag,
-        _showDragHandleForBottomSheet = showDragHandleForBottomSheet,
+        _showDragHandle = showDragHandle,
         _useSafeArea = useSafeArea ?? true,
         _transitionAnimationController = transitionAnimationController,
         _transitionDuration = transitionDuration ?? const Duration(milliseconds: 300),
@@ -64,7 +64,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
 
   final bool? _enableDrag;
 
-  final bool? _showDragHandleForBottomSheet;
+  final bool? _showDragHandle;
 
   final bool _useSafeArea;
 
@@ -126,7 +126,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
       onModalDismissedWithDrag: onModalDismissedWithDrag,
       animationController: animationController,
       enableDrag: _enableDrag,
-      showDragHandleForBottomSheet: _showDragHandleForBottomSheet,
+      showDragHandle: _showDragHandle,
       useSafeArea: _useSafeArea,
       minDialogWidth: _minDialogWidth,
       maxDialogWidth: _maxDialogWidth,

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -18,7 +18,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     this.onModalDismissedWithDrag,
     this.modalBarrierColor,
     WoltModalTypeBuilder? modalTypeBuilder,
-    bool? enableDragForBottomSheet,
+    bool? enableDrag,
     bool? showDragHandleForBottomSheet,
     bool? useSafeArea,
     bool? barrierDismissible,
@@ -31,7 +31,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     double? maxDialogWidth,
     double? minPageHeight,
     double? maxPageHeight,
-  })  : _enableDragForBottomSheet = enableDragForBottomSheet,
+  })  : _enableDrag = enableDrag,
         _showDragHandleForBottomSheet = showDragHandleForBottomSheet,
         _useSafeArea = useSafeArea ?? true,
         _transitionAnimationController = transitionAnimationController,
@@ -62,7 +62,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
 
   final VoidCallback? onModalDismissedWithDrag;
 
-  final bool? _enableDragForBottomSheet;
+  final bool? _enableDrag;
 
   final bool? _showDragHandleForBottomSheet;
 
@@ -125,7 +125,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
       onModalDismissedWithDrag: onModalDismissedWithDrag,
       animationController: animationController,
-      enableDragForBottomSheet: _enableDragForBottomSheet,
+      enableDrag: _enableDrag,
       showDragHandleForBottomSheet: _showDragHandleForBottomSheet,
       useSafeArea: _useSafeArea,
       minDialogWidth: _minDialogWidth,

--- a/playground/lib/home/dynamic_page_properties.dart
+++ b/playground/lib/home/dynamic_page_properties.dart
@@ -10,15 +10,15 @@ class DynamicPagePropertiesNotifier extends ValueNotifier<DynamicPagePropertiesM
 /// A model class that represents the dynamic properties of a page.
 class DynamicPagePropertiesModel {
   /// Indicates whether dragging is enabled for the bottom sheet.
-  final bool enableDragForBottomSheet;
+  final bool enableDrag;
 
   /// Creates a [DynamicPagePropertiesModel] with the provided properties.
-  DynamicPagePropertiesModel({required this.enableDragForBottomSheet});
+  DynamicPagePropertiesModel({required this.enableDrag});
 
   /// Creates a copy of [DynamicPagePropertiesModel] with optional property updates.
-  DynamicPagePropertiesModel copyWith({bool? enableDragForBottomSheet}) {
+  DynamicPagePropertiesModel copyWith({bool? enableDrag}) {
     return DynamicPagePropertiesModel(
-      enableDragForBottomSheet: enableDragForBottomSheet ?? this.enableDragForBottomSheet,
+      enableDrag: enableDrag ?? this.enableDrag,
     );
   }
 }

--- a/playground/lib/home/dynamic_page_properties.dart
+++ b/playground/lib/home/dynamic_page_properties.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+/// A [ValueNotifier] that holds and manages the state of the dynamic properties for a [WoltModalSheetPage].
+class DynamicPagePropertiesNotifier extends ValueNotifier<DynamicPagePropertiesModel> {
+  /// Constructs a [DynamicPagePropertiesNotifier] instance with the initial [value].
+  DynamicPagePropertiesNotifier(DynamicPagePropertiesModel value) : super(value);
+}
+
+/// A model class that represents the dynamic properties of a page.
+class DynamicPagePropertiesModel {
+  /// Indicates whether dragging is enabled for the bottom sheet.
+  final bool enableDragForBottomSheet;
+
+  /// Creates a [DynamicPagePropertiesModel] with the provided properties.
+  DynamicPagePropertiesModel({required this.enableDragForBottomSheet});
+
+  /// Creates a copy of [DynamicPagePropertiesModel] with optional property updates.
+  DynamicPagePropertiesModel copyWith({bool? enableDragForBottomSheet}) {
+    return DynamicPagePropertiesModel(
+      enableDragForBottomSheet: enableDragForBottomSheet ?? this.enableDragForBottomSheet,
+    );
+  }
+}
+
+/// An [InheritedNotifier] that provides access to the dynamic page properties within its subtree.
+class DynamicPageProperties extends InheritedNotifier<DynamicPagePropertiesNotifier> {
+  /// Creates an instance of [DynamicPageProperties].
+  ///
+  /// The [notifier] holds the [DynamicPagePropertiesNotifier] that manages the dynamic page properties,
+  /// and [child] is the widget subtree that this inherited widget wraps.
+  const DynamicPageProperties({
+    super.key,
+    required DynamicPagePropertiesNotifier notifier,
+    required Widget child,
+  }) : super(notifier: notifier, child: child);
+
+  /// Retrieves the [DynamicPagePropertiesNotifier] from the nearest ancestor [DynamicPageProperties].
+  static DynamicPagePropertiesNotifier? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DynamicPageProperties>()?.notifier;
+  }
+}

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -120,7 +120,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     decorator: (child) {
                       return DynamicPageProperties(
                         notifier: DynamicPagePropertiesNotifier(
-                          DynamicPagePropertiesModel(enableDragForBottomSheet: true),
+                          DynamicPagePropertiesModel(enableDrag: true),
                         ),
                         child: child,
                       );

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:playground/home/dynamic_page_properties.dart';
 import 'package:playground/home/pages/multi_page_path_name.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 import 'package:wolt_responsive_layout_grid/wolt_responsive_layout_grid.dart';
@@ -115,6 +116,14 @@ class _HomeScreenState extends State<HomeScreen> {
                       debugPrint('Modal is dismissed with barrier tap.');
                       Navigator.of(context).pop();
                       pageIndexNotifier.value = 0;
+                    },
+                    decorator: (child) {
+                      return DynamicPageProperties(
+                        notifier: DynamicPagePropertiesNotifier(
+                          DynamicPagePropertiesModel(enableDragForBottomSheet: true),
+                        ),
+                        child: child,
+                      );
                     },
                     maxDialogWidth: 560,
                     minDialogWidth: 400,

--- a/playground/lib/home/pages/multi_page_path_name.dart
+++ b/playground/lib/home/pages/multi_page_path_name.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:playground/home/pages/root_sheet_page.dart';
+import 'package:playground/home/pages/sheet_page_with_dynamic_page_properties.dart';
 import 'package:playground/home/pages/sheet_page_with_forced_max_height.dart';
 import 'package:playground/home/pages/sheet_page_with_hero_image.dart';
 import 'package:playground/home/pages/sheet_page_with_lazy_list.dart';
@@ -14,6 +15,7 @@ enum MultiPagePathName {
   lazyLoadingList(pageCount: 2, queryParamName: "lazyList"),
   textField(pageCount: 2, queryParamName: "textField"),
   noTitleNoTopBar(pageCount: 2, queryParamName: "noTitleNoTopBar"),
+  dynamicPageProperties(pageCount: 2, queryParamName: "dynamicPageProperties"),
   allPagesPath(pageCount: 6, queryParamName: "all");
 
   static const defaultPath = MultiPagePathName.allPagesPath;
@@ -64,6 +66,14 @@ enum MultiPagePathName {
           onBackPressed: goToPreviousPage,
           isLastPage: isLastPage,
         );
+    WoltModalSheetPage dynamicPageProperties(BuildContext context, {bool isLastPage = true}) =>
+        SheetPageWithDynamicPageProperties.build(
+          onSabPressed: () => isLastPage ? close(context) : goToNextPage(),
+          onClosed: () => close(context),
+          onBackPressed: goToPreviousPage,
+          context: context,
+          isLastPage: isLastPage,
+        );
     WoltModalSheetPage textField(BuildContext context, {bool isLastPage = true}) =>
         SheetPageWithTextField.build(
           onSabPressed: () => isLastPage ? close(context) : goToNextPage(),
@@ -82,6 +92,8 @@ enum MultiPagePathName {
         return (context) => [root(context), textField(context)];
       case MultiPagePathName.noTitleNoTopBar:
         return (context) => [root(context), noTitleNoTopBar(context)];
+      case MultiPagePathName.dynamicPageProperties:
+        return (context) => [root(context), dynamicPageProperties(context)];
       case MultiPagePathName.allPagesPath:
         return (context) => [
               root(context),
@@ -89,6 +101,7 @@ enum MultiPagePathName {
               lazyList(context, isLastPage: false),
               textField(context, isLastPage: false),
               noTitleNoTopBar(context, isLastPage: false),
+              dynamicPageProperties(context, isLastPage: false),
               forcedMaxHeight(context, isLastPage: true),
             ];
     }

--- a/playground/lib/home/pages/root_sheet_page.dart
+++ b/playground/lib/home/pages/root_sheet_page.dart
@@ -62,6 +62,11 @@ class RootSheetPage {
                 isSelected: false,
               ),
               WoltSelectionListItemData(
+                title: 'Page with dynamic properties',
+                value: MultiPagePathName.dynamicPageProperties,
+                isSelected: false,
+              ),
+              WoltSelectionListItemData(
                 title: 'All the pages in one flow',
                 value: MultiPagePathName.allPagesPath,
                 isSelected: false,

--- a/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
+++ b/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
@@ -1,0 +1,54 @@
+import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/material.dart';
+import 'package:playground/home/dynamic_page_properties.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class SheetPageWithDynamicPageProperties {
+  SheetPageWithDynamicPageProperties._();
+
+  static WoltModalSheetPage build({
+    required VoidCallback onSabPressed,
+    required VoidCallback onBackPressed,
+    required VoidCallback onClosed,
+    required BuildContext context,
+    bool isLastPage = true,
+  }) {
+    final dynamicPageModel = DynamicPageProperties.of(context)!;
+    bool useOriginalPageValues = true;
+    return WoltModalSheetPage.withSingleChild(
+      hasSabGradient: false,
+      enableDragForBottomSheet: dynamicPageModel.value.enableDragForBottomSheet,
+      stickyActionBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: WoltElevatedButton(
+          onPressed: onSabPressed,
+          colorName: WoltColorName.green,
+          child: Text(isLastPage ? "Close" : "Next"),
+        ),
+      ),
+      isTopBarLayerAlwaysVisible: true,
+      topBarTitle: const ModalSheetTopBarTitle('Dynamic page properties'),
+      leadingNavBarWidget: WoltModalSheetBackButton(onBackPressed: onBackPressed),
+      trailingNavBarWidget: WoltModalSheetCloseButton(onClosed: onClosed),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 100),
+        child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+          return Row(
+            children: [
+              const Expanded(child: Text('Enable Drag for Bottom Sheet')),
+              Switch(
+                value: useOriginalPageValues,
+                onChanged: (newValue) {
+                  dynamicPageModel.value = dynamicPageModel.value.copyWith(
+                    enableDragForBottomSheet: newValue,
+                  );
+                  setState(() => useOriginalPageValues = !useOriginalPageValues);
+                },
+              ),
+            ],
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
+++ b/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:playground/home/dynamic_page_properties.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
+/// This is a page that is shown in the modal sheet to demonstrate how to change the page
+/// properties dynamically.
 class SheetPageWithDynamicPageProperties {
   SheetPageWithDynamicPageProperties._();
 
@@ -17,7 +19,7 @@ class SheetPageWithDynamicPageProperties {
     bool useOriginalPageValues = true;
     return WoltModalSheetPage.withSingleChild(
       hasSabGradient: false,
-      enableDragForBottomSheet: dynamicPageModel.value.enableDragForBottomSheet,
+      enableDrag: dynamicPageModel.value.enableDrag,
       stickyActionBar: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         child: WoltElevatedButton(
@@ -40,7 +42,7 @@ class SheetPageWithDynamicPageProperties {
                 value: useOriginalPageValues,
                 onChanged: (newValue) {
                   dynamicPageModel.value = dynamicPageModel.value.copyWith(
-                    enableDragForBottomSheet: newValue,
+                    enableDrag: newValue,
                   );
                   setState(() => useOriginalPageValues = !useOriginalPageValues);
                 },


### PR DESCRIPTION
Don't merge this PR before #44 

### Summary

This pull request introduces a new feature that enhances the behavior of the `WoltModalSheet` library by allowing the enabling or disabling of drag-to-dismiss functionality for the bottom sheet on a per-page basis. The primary change is the addition of the `enableDragForBottomSheet` property within the `WoltModalSheetPage` class.

### Changes

- Added a new property `enableDragForBottomSheet` to the `WoltModalSheetPage` class.
- Enhanced the `WoltBottomSheetDragHandle` to be conditionally displayed based on the `enableDragForBottomSheet` property.
- Added a new use case to the `playground` example app to demonstrate how to dynamically enable/disable drag for modal sheet.
- Updated documentation and examples to demonstrate the usage of the new feature.

### Use Case

This feature addition addresses a common use case where dynamic conditions dictate whether a bottom sheet can be dismissed by dragging or not. By providing this per-page option, developers can create more tailored and flexible user experiences, enabling or disabling the drag-to-dismiss behavior based on specific context and requirements.

#### Example

```dart
WoltModalSheetPage(
  enableDragForBottomSheet: shouldEnableDrag, // Enable or disable drag-to-dismiss
  // ... other page properties ...
)
```

https://github.com/woltapp/wolt_modal_sheet/assets/13782003/8107cb17-37a2-4480-91a7-826aa7025762






