### PR TITLE
Prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Documentation updates. [#54](https://github.com/woltapp/wolt_modal_sheet/pull/54)
+
 ## 0.1.1
 
 - Documentation updates. [#53](https://github.com/woltapp/wolt_modal_sheet/pull/53)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ this layer guides the user towards the next step, uses an optional gentle
 gradient on top to hint that there is more content below ready for scrolling.</li>
 </br>
 
-![Modal sheet page layers](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/modal_sheet_page.png)
+![Modal sheet page layers](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/modal_sheet_page.png?raw=true)
 </br>
 
 By employing these various layers, you can create an interactive and visually
@@ -95,7 +95,7 @@ overall coherence of the page, serving a specific purpose and enhancing the
 overall user experience.
 </br>
 
-![Modal sheet elements breakdown](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/bottom_sheet_elements.jpeg)
+![Modal sheet elements breakdown](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/bottom_sheet_elements.jpeg?raw=true)
 
 ### Navigation bar widgets
 
@@ -155,7 +155,7 @@ performance.
 
 Here is an example that shows all the modal sheet elements in use:
 
-![Modal sheet elements in use](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/bottom_sheet_example.jpeg)
+![Modal sheet elements in use](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/bottom_sheet_example.jpeg?raw=true)
 
 ## Getting started
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,6 +182,6 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.2"
 sdks:
   dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wolt_modal_sheet
 description: This package provides a responsive modal with multiple pages, motion animation for page transitions, and scrollable content within each page.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/woltapp/wolt_modal_sheet
 
 environment:


### PR DESCRIPTION
**Updates broken image links for pub.dev**
For pub.dev to display images we need to add `raw=true` to image links or use `https://raw.githubusercontent.com` kind a format