### PR TITLE
[Issue-55] Fix `barrierDismissible` parameter has no effect to prevent modal dismissing

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -234,9 +234,7 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                       themeData?.enableDrag ??
                       defaultThemeData.enableDrag);
               final showDragHandle = widget.showDragHandle ??
-                  (enableDrag &&
-                      (themeData?.showDragHandle ??
-                          defaultThemeData.showDragHandle));
+                  (enableDrag && (themeData?.showDragHandle ?? defaultThemeData.showDragHandle));
               final pageBackgroundColor = page.backgroundColor ??
                   themeData?.backgroundColor ??
                   defaultThemeData.backgroundColor;
@@ -273,7 +271,17 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
                     id: barrierLayoutId,
                     child: GestureDetector(
                       behavior: HitTestBehavior.opaque,
-                      onTap: widget.onModalDismissedWithBarrierTap ?? Navigator.of(context).pop,
+                      onTap: () {
+                        if (widget.route.barrierDismissible) {
+                          final onModalDismissedWithBarrierTap =
+                              widget.onModalDismissedWithBarrierTap;
+                          if (onModalDismissedWithBarrierTap != null) {
+                            onModalDismissedWithBarrierTap();
+                          } else {
+                            Navigator.of(context).pop();
+                          }
+                        }
+                      },
                       child: const SizedBox.expand(),
                     ),
                   ),

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -7,30 +7,25 @@ void main() {
     testWidgets('WoltModalSheet.show opens a sheet', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: Builder(
-                builder: (context) {
-                  return ElevatedButton(
-                    onPressed: () {
-                      WoltModalSheet.show(
-                        context: context,
-                        pageListBuilder: (context) {
-                          return <WoltModalSheetPage>[
-                            WoltModalSheetPage.withSingleChild(
-                              child: const Text('Wolt modal sheet page'),
-                            ),
-                          ];
-                        },
-                      );
+          home: Scaffold(body: Center(
+            child: Builder(builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  WoltModalSheet.show(
+                    context: context,
+                    pageListBuilder: (context) {
+                      return <WoltModalSheetPage>[
+                        WoltModalSheetPage.withSingleChild(
+                          child: const Text('Wolt modal sheet page'),
+                        ),
+                      ];
                     },
-                    child: const Text('Open sheet'),
                   );
-
-                }
-              ),
-            )
-          ),
+                },
+                child: const Text('Open sheet'),
+              );
+            }),
+          )),
         ),
       );
 
@@ -43,25 +38,21 @@ void main() {
     testWidgets('Empty pageListBuilder throws an error', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: Builder(
-                builder: (context) {
-                  return ElevatedButton(
-                    onPressed: () {
-                      WoltModalSheet.show(
-                        context: context,
-                        pageListBuilder: (context) {
-                          return <WoltModalSheetPage>[];
-                        },
-                      );
+          home: Scaffold(body: Center(
+            child: Builder(builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  WoltModalSheet.show(
+                    context: context,
+                    pageListBuilder: (context) {
+                      return <WoltModalSheetPage>[];
                     },
-                    child: const Text('Open sheet'),
                   );
-                }
-              ),
-            )
-          ),
+                },
+                child: const Text('Open sheet'),
+              );
+            }),
+          )),
         ),
       );
 
@@ -70,6 +61,110 @@ void main() {
 
       expect(tester.takeException(), isNotNull);
     });
+  });
+
+  group('Modal sheet barrier dismissible', () {
+    testWidgets('WoltModalSheet does not dismiss on barrier tap if barrierDismissible is false',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Center(
+            child: Builder(builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  WoltModalSheet.show(
+                    context: context,
+                    barrierDismissible: false,
+                    onModalDismissedWithDrag: () => Navigator.of(context).pop(),
+                    pageListBuilder: (context) {
+                      return <WoltModalSheetPage>[
+                        WoltModalSheetPage.withSingleChild(
+                          child: const Text('Wolt modal sheet page'),
+                        ),
+                      ];
+                    },
+                  );
+                },
+                child: const Text('Open sheet'),
+              );
+            }),
+          )),
+        ),
+      );
+
+      await tester.tap(find.text('Open sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Wolt modal sheet page'), findsOneWidget);
+
+      await tester.tapAt(const Offset(0, 0));
+      await tester.pumpAndSettle();
+      expect(find.text('Wolt modal sheet page'), findsOneWidget);
+    });
+
+    testWidgets('WoltModalSheet dismisses on barrier tap if barrierDismissible is true',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Center(
+            child: Builder(builder: (context) {
+              return ElevatedButton(
+                onPressed: () {
+                  WoltModalSheet.show(
+                    context: context,
+                    barrierDismissible: true,
+                    pageListBuilder: (context) {
+                      return <WoltModalSheetPage>[
+                        WoltModalSheetPage.withSingleChild(
+                          child: const Text('Wolt modal sheet page'),
+                        ),
+                      ];
+                    },
+                  );
+                },
+                child: const Text('Open sheet'),
+              );
+            }),
+          )),
+        ),
+      );
+
+      await tester.tap(find.text('Open sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Wolt modal sheet page'), findsOneWidget);
+
+      await tester.tapAt(const Offset(0, 0));
+      await tester.pumpAndSettle();
+      expect(find.text('Wolt modal sheet page'), findsNothing);
+    });
+  });
+
+  testWidgets('Empty pageListBuilder throws an error', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: Center(
+          child: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () {
+                WoltModalSheet.show(
+                  context: context,
+                  pageListBuilder: (context) {
+                    return <WoltModalSheetPage>[];
+                  },
+                );
+              },
+              child: const Text('Open sheet'),
+            );
+          }),
+        )),
+      ),
+    );
+
+    await tester.tap(find.text('Open sheet'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNotNull);
   });
 
   testWidgets('WoltModalSheet.modalTypeBuilder defaults', (tester) async {
@@ -82,29 +177,25 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: Builder(
-              builder: (context) {
-                return ElevatedButton(
-                  onPressed: () {
-                    WoltModalSheet.show(
-                      context: context,
-                      pageListBuilder: (context) {
-                        return <WoltModalSheetPage>[
-                          WoltModalSheetPage.withSingleChild(
-                            child: const Text('Wolt modal sheet page'),
-                          ),
-                        ];
-                      },
-                    );
+        home: Scaffold(body: Center(
+          child: Builder(builder: (context) {
+            return ElevatedButton(
+              onPressed: () {
+                WoltModalSheet.show(
+                  context: context,
+                  pageListBuilder: (context) {
+                    return <WoltModalSheetPage>[
+                      WoltModalSheetPage.withSingleChild(
+                        child: const Text('Wolt modal sheet page'),
+                      ),
+                    ];
                   },
-                  child: const Text('Open sheet'),
                 );
-              }
-            ),
-          )
-        ),
+              },
+              child: const Text('Open sheet'),
+            );
+          }),
+        )),
       ),
     );
 


### PR DESCRIPTION
### Description

This PR addresses the bug where even when barrierDismissible was set to false, the modal could still be dismissed when tapping on the barrier.

### Changes
Added a condition to check for `barrierDismissible`. If it's true, only then it will decide whether to use onModalDismissedWithBarrierTap or fall back to Navigator.of(context).pop.

### Added Tests
Ensure that when `barrierDismissible` is true, the modal can be dismissed by tapping outside.
Ensure that when `barrierDismissible` is false, the modal cannot be dismissed by tapping outside.

By making this change, we ensure that the modal dismissal respects the `barrierDismissible` property, and it provides a consistent user experience.