### PR TITLE
Remove extra scrollbars in the modal sheet due to nested scroll views

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/content/components/main_content/wolt_modal_sheet_hero_image.dart';
 import 'package:wolt_modal_sheet/src/theme/wolt_modal_sheet_default_theme_data.dart';
+import 'package:wolt_modal_sheet/src/utils/drag_scroll_behavior.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 /// The main content widget within the scrollable modal sheet.
@@ -56,6 +57,7 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     final singleChildContent = widget.page.singleChildContent;
     final sliverList = widget.page.sliverList;
     final scrollView = CustomScrollView(
+      scrollBehavior: const DragScrollBehavior(),
       shrinkWrap: true,
       physics: const ClampingScrollPhysics(),
       controller: scrollController,
@@ -86,7 +88,10 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
         (singleChildContent != null
                 ? SliverList(
                     delegate: SliverChildBuilderDelegate(
-                      (_, __) => singleChildContent,
+                      (_, __) => ScrollConfiguration(
+                        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+                        child: singleChildContent,
+                      ),
                       childCount: 1,
                     ),
                   )

--- a/lib/src/content/wolt_modal_sheet_layout.dart
+++ b/lib/src/content/wolt_modal_sheet_layout.dart
@@ -31,40 +31,37 @@ class WoltModalSheetLayout extends StatelessWidget {
     final topBarHeight = hasTopBarLayer
         ? (page.navBarHeight ?? themeData?.navBarHeight ?? defaultThemeData.navBarHeight)
         : 0.0;
-    return ScrollConfiguration(
-      behavior: const DragScrollBehavior(),
-      child: Stack(
-        children: [
-          paginatingWidgetsGroup.mainContentAnimatedBuilder,
-          if (hasTopBarLayer)
-            Positioned(
-              left: 0,
-              right: 0,
-              top: 0,
-              height: topBarHeight,
-              child: paginatingWidgetsGroup.topBarAnimatedBuilder,
-            ),
-          if (showDragHandle)
-            const Positioned(
-              left: 0,
-              right: 0,
-              top: 0,
-              child: WoltBottomSheetDragHandle(),
-            ),
+    return Stack(
+      children: [
+        paginatingWidgetsGroup.mainContentAnimatedBuilder,
+        if (hasTopBarLayer)
           Positioned(
+            left: 0,
+            right: 0,
             top: 0,
+            height: topBarHeight,
+            child: paginatingWidgetsGroup.topBarAnimatedBuilder,
+          ),
+        if (showDragHandle)
+          const Positioned(
             left: 0,
             right: 0,
-            child: paginatingWidgetsGroup.navigationToolbarAnimatedBuilder,
+            top: 0,
+            child: WoltBottomSheetDragHandle(),
           ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: paginatingWidgetsGroup.sabAnimatedBuilder,
-          ),
-        ],
-      ),
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          child: paginatingWidgetsGroup.navigationToolbarAnimatedBuilder,
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: paginatingWidgetsGroup.sabAnimatedBuilder,
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
# Description:

Issue reported within #46 

This PR addresses an issue where an extra scrollbar was being displayed in web and desktop apps when a nested scroll view was present within a modal page constructed with `withSingleChild` factory method.

## Changes Made:

Wrapped the singleChildContent within a [ScrollConfiguration](https://api.flutter.dev/flutter/widgets/ScrollConfiguration-class.html) widget the copy of the parent scroll behavior and changed the scrollbars to false for the descendants.

| Before  | After |
| ------------- | ------------- |
|  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/25342b62-2c29-4699-b253-9f5bf86d271e"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/1b3c937d-ae90-4562-b67a-fbe926e48245"> |
