### PR TITLE
Throw a helpful error message when returning an empty list in `pageListBuilder`

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -215,6 +215,7 @@ class _WoltModalSheetState extends State<WoltModalSheet> {
         valueListenable: pagesListBuilderNotifier,
         builder: (context, pagesBuilder, _) {
           final pages = pagesBuilder(context);
+          assert(pages.isNotEmpty, 'pageListBuilder must return a non-empty list.');
           return ValueListenableBuilder<int>(
             valueListenable: pageIndexNotifier,
             builder: (_, int pageIndex, __) {

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -59,7 +59,9 @@ void main() {
       await tester.tap(find.text('Open sheet'));
       await tester.pumpAndSettle();
 
-      expect(tester.takeException(), isNotNull);
+      final AssertionError exception = tester.takeException() as AssertionError;
+      expect(exception, isAssertionError);
+      expect(exception.message, 'pageListBuilder must return a non-empty list.');
     });
   });
 


### PR DESCRIPTION
fixes [Throw a helpful error when returning an empty list in `pageListBuilder`](https://github.com/woltapp/wolt_modal_sheet/issues/33)