### PR TITLE
Update the package & examples to support minimum Flutter `v3.7.2`

### DIFF
--- a/coffee_maker/pubspec.yaml
+++ b/coffee_maker/pubspec.yaml
@@ -3,7 +3,8 @@ description: The coffee maker example project to demonstrate the usage of wolt_m
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/demo_ui_components/pubspec.yaml
+++ b/demo_ui_components/pubspec.yaml
@@ -1,8 +1,10 @@
 name: demo_ui_components
 description: Module to contain commonly shared ui components in example modules
 publish_to: "none"
+
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=2.19.6 <4.0.0'
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/lib/src/content/components/paginating_group/main_content_animated_builder.dart
+++ b/lib/src/content/components/paginating_group/main_content_animated_builder.dart
@@ -48,7 +48,7 @@ class _MainContentAnimatedBuilderState extends State<MainContentAnimatedBuilder>
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.sizeOf(context).width;
+    final screenWidth = MediaQuery.of(context).size.width;
     final controller = widget.controller;
     final pageTransitionState = widget.pageTransitionState;
     return AnimatedBuilder(

--- a/playground/lib/home/pages/sheet_page_with_custom_top_bar.dart
+++ b/playground/lib/home/pages/sheet_page_with_custom_top_bar.dart
@@ -31,9 +31,9 @@ class SheetPageWithCustomTopBar {
       isTopBarLayerAlwaysVisible: false,
       topBar: _CustomTopBar(onClosed: onClosed, onBackPressed: onBackPressed),
       pageTitle: const ModalSheetTitle('Page with custom top bar'),
-      child: const Column(
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+        children: const [
           Padding(
             padding: EdgeInsets.all(16.0),
             child: Text('Scroll to see the custom top bar with a search field in it.'),
@@ -71,9 +71,10 @@ class _CustomTopBar extends StatelessWidget {
           Expanded(
             child: Padding(
               padding: _searchBarPadding,
-              child: SearchBar(
-                hintText: 'Search',
-                onChanged: (value) {},
+              child: IconButton(
+                onPressed: () {},
+                tooltip: 'Search',
+                icon: const Icon(Icons.search),
               ),
             ),
           ),

--- a/playground/lib/home/pages/sheet_page_with_lazy_list.dart
+++ b/playground/lib/home/pages/sheet_page_with_lazy_list.dart
@@ -24,8 +24,8 @@ class SheetPageWithLazyList {
       ),
       topBarTitle: const ModalSheetTopBarTitle(titleText),
       heroImageHeight: heroImageHeight,
-      heroImage: const Stack(
-        children: [
+      heroImage: Stack(
+        children: const [
           ColoredBox(
             color: Colors.yellow,
             child: SizedBox(height: heroImageHeight, width: double.infinity),

--- a/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
+++ b/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
@@ -23,10 +23,10 @@ class SheetPageWithNoPageTitleNoTopBar {
         ),
       ),
       hasTopBarLayer: false,
-      child: const Padding(
-        padding: EdgeInsets.all(16.0),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
         child: Column(
-          children: [
+          children: const [
             Text(
               '''
 This page has a very long scrollable content and does not have a page title and top bar.

--- a/playground/pubspec.yaml
+++ b/playground/pubspec.yaml
@@ -1,8 +1,10 @@
 name: playground
 description: A playground to test various use cases with the wolt modal sheet with imperative navigation
 publish_to: "none"
+
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/playground_navigator2/pubspec.yaml
+++ b/playground_navigator2/pubspec.yaml
@@ -1,8 +1,10 @@
 name: playground_navigator2
 description: A playground to test various use cases with the wolt modal sheet with declarative navigation
 publish_to: "none"
+
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,8 @@ version: 0.1.3
 repository: https://github.com/woltapp/wolt_modal_sheet
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.19.2 <4.0.0'
+  flutter: '>=3.7.2'
 
 dependencies:
   flutter:

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -173,9 +173,8 @@ void main() {
     const Size wideSize = Size(800.0, 600.0);
     const Size narrowSize = Size(300.0, 600.0);
 
-    addTearDown(tester.view.reset);
-    tester.view.physicalSize = wideSize;
-    tester.view.devicePixelRatio = 1.0;
+    tester.binding.window.physicalSizeTestValue = wideSize;
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -207,15 +206,19 @@ void main() {
     Finder sheetMaterial = find.byType(Material).last;
 
     // The default modalTypeBuilder should be a dialog on wide screens.
-    expect(tester.getSize(sheetMaterial), const Size(320.0, 160.0));
-    expect(tester.getTopLeft(sheetMaterial), const Offset(240.0, 220.0));
+    expect(tester.getSize(sheetMaterial), const Size(400.0, 71.0));
+    expect(tester.getTopLeft(sheetMaterial), const Offset(200.0, 253.0));
 
     // Configure to show the narrow layout.
-    tester.view.physicalSize = narrowSize;
+    tester.binding.window.physicalSizeTestValue = narrowSize;
     await tester.pumpAndSettle();
 
     // The default modalTypeBuilder should be a bottom sheet on narrow screens.
-    expect(tester.getSize(sheetMaterial), const Size(300.0, 160.0));
-    expect(tester.getTopLeft(sheetMaterial), const Offset(0.0, 440.0));
+    expect(tester.getSize(sheetMaterial), const Size(300.0, 71.0));
+    expect(tester.getTopLeft(sheetMaterial), const Offset(0.0, 510.0));
+
+    // Reset the physical size and device pixel ratio.
+    tester.binding.window.clearPhysicalSizeTestValue();
+    tester.binding.window.clearDevicePixelRatioTestValue();
   });
 }


### PR DESCRIPTION
fixes [App cannot build on older Flutter verrsion - Throws `Error: Member not found: 'MediaQuery.sizeOf`](https://github.com/woltapp/wolt_modal_sheet/issues/76)
fixes [Update minimum supported Flutter version to `3.7.2`](https://github.com/woltapp/wolt_modal_sheet/issues/80)

This PR sets the minimum Flutter version to be `3.7.2` and matches the Dart SDK version bundled in this release. 
It means a users should have at least Flutter `3.7.2` installed.

- Updated APIs to be compatible to with this requirement
- Replaced `SearchBar` with `IconButton` in playground as it doesn't exist in `3.7.2`
- Updated a test to use older API

