### PR TITLE
WoltModalSheetPageTransitionState - Change parameter from Controller to Animation<double>

### DIFF
--- a/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
+++ b/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
@@ -6,18 +6,17 @@ enum WoltModalSheetPageTransitionState {
 
   const WoltModalSheetPageTransitionState();
 
-  Animation<double> defaultMainContentSizeFactor(
-      AnimationController controller) {
+  Animation<double> defaultMainContentSizeFactor(Animation<double> animation) {
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
-        return Tween<double>(begin: 0.0, end: 1.0).animate(controller);
+        return Tween<double>(begin: 0.0, end: 1.0).animate(animation);
       case WoltModalSheetPageTransitionState.outgoing:
-        return Tween<double>(begin: 1.0, end: 0.0).animate(controller);
+        return Tween<double>(begin: 1.0, end: 0.0).animate(animation);
     }
   }
 
   Animation<double> mainContentSizeFactor(
-    AnimationController controller, {
+    Animation<double> animation, {
     required double incomingMainContentHeight,
     required double outgoingMainContentHeight,
   }) {
@@ -27,28 +26,28 @@ enum WoltModalSheetPageTransitionState {
         return Tween<double>(
                 begin: outgoingMainContentHeight / incomingMainContentHeight,
                 end: 1.0)
-            .animate(CurvedAnimation(parent: controller, curve: interval));
+            .animate(CurvedAnimation(parent: animation, curve: interval));
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<double>(
                 begin: 1.0,
                 end: incomingMainContentHeight / outgoingMainContentHeight)
-            .animate(CurvedAnimation(parent: controller, curve: interval));
+            .animate(CurvedAnimation(parent: animation, curve: interval));
     }
   }
 
-  Animation<double> mainContentOpacity(AnimationController controller) {
+  Animation<double> mainContentOpacity(Animation<double> animation) {
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
         return Tween<double>(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(150 / 350, 350 / 350, curve: Curves.linear),
           ),
         );
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<double>(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(50 / 350, 150 / 350, curve: Curves.linear),
           ),
         );
@@ -56,7 +55,7 @@ enum WoltModalSheetPageTransitionState {
   }
 
   Animation<Offset> mainContentSlidePosition(
-    AnimationController controller, {
+    Animation<double> animation, {
     required double sheetWidth,
     required double screenWidth,
     required bool isForwardMove,
@@ -68,67 +67,67 @@ enum WoltModalSheetPageTransitionState {
           begin: Offset(
               sheetWidth * 0.3 * (isForwardMove ? 1 : -1) / screenWidth, 0),
           end: Offset.zero,
-        ).animate(CurvedAnimation(parent: controller, curve: interval));
+        ).animate(CurvedAnimation(parent: animation, curve: interval));
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<Offset>(
           begin: Offset.zero,
           end: Offset(
               sheetWidth * 0.3 * (isForwardMove ? -1 : 1) / screenWidth, 0),
-        ).animate(CurvedAnimation(parent: controller, curve: interval));
+        ).animate(CurvedAnimation(parent: animation, curve: interval));
     }
   }
 
-  Animation<double> navigationToolbarOpacity(AnimationController controller) {
+  Animation<double> navigationToolbarOpacity(Animation<double> animation) {
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
         return Tween<double>(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(100 / 350, 300 / 350, curve: Curves.linear),
           ),
         );
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<double>(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(0, 100 / 350, curve: Curves.linear),
           ),
         );
     }
   }
 
-  Animation<double> sabOpacity(AnimationController controller) {
+  Animation<double> sabOpacity(Animation<double> animation) {
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
         return Tween<double>(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(100 / 350, 300 / 350, curve: Curves.linear),
           ),
         );
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<double>(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(0, 100 / 350),
           ),
         );
     }
   }
 
-  Animation<double> topBarOpacity(AnimationController controller) {
+  Animation<double> topBarOpacity(Animation<double> animation) {
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
         return Tween<double>(begin: 0.0, end: 1.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(150 / 350, 350 / 350, curve: Curves.linear),
           ),
         );
       case WoltModalSheetPageTransitionState.outgoing:
         return Tween<double>(begin: 1.0, end: 0.0).animate(
           CurvedAnimation(
-            parent: controller,
+            parent: animation,
             curve: const Interval(0, 150 / 350, curve: Curves.linear),
           ),
         );


### PR DESCRIPTION
We would like to use some of the functions of `WoltModalSheetPageTransitionState` in  some other animations, but we don't have an AnimationController. 

The `animate` of the Tween just need an Animation<double>, so it doesn't change any other file.