### PR TITLE
Fix overflow scroll effect visibility when top bar is always visible

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -45,17 +45,22 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     final page = widget.page;
     final heroImageHeight = page.heroImage == null
         ? 0.0
-        : (page.heroImageHeight ?? themeData?.heroImageHeight ?? defaultThemeData.heroImageHeight);
-    final pageHasTopBarLayer =
-        page.hasTopBarLayer ?? themeData?.hasTopBarLayer ?? defaultThemeData.hasTopBarLayer;
+        : (page.heroImageHeight ??
+            themeData?.heroImageHeight ??
+            defaultThemeData.heroImageHeight);
+    final pageHasTopBarLayer = page.hasTopBarLayer ??
+        themeData?.hasTopBarLayer ??
+        defaultThemeData.hasTopBarLayer;
     final isTopBarLayerAlwaysVisible =
         pageHasTopBarLayer && page.isTopBarLayerAlwaysVisible == true;
-    final navBarHeight =
-        page.navBarHeight ?? themeData?.navBarHeight ?? defaultThemeData.navBarHeight;
-    final topBarHeight =
-        pageHasTopBarLayer || page.leadingNavBarWidget != null || page.trailingNavBarWidget != null
-            ? navBarHeight
-            : 0.0;
+    final navBarHeight = page.navBarHeight ??
+        themeData?.navBarHeight ??
+        defaultThemeData.navBarHeight;
+    final topBarHeight = pageHasTopBarLayer ||
+            page.leadingNavBarWidget != null ||
+            page.trailingNavBarWidget != null
+        ? navBarHeight
+        : 0.0;
     final scrollView = CustomScrollView(
       scrollBehavior: const DragScrollBehavior(),
       shrinkWrap: true,
@@ -76,7 +81,8 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
                     // If top bar layer is always visible, the padding is explicitly added to the
                     // scroll view since top bar will not be integrated to scroll view at all.
                     // Otherwise, we implicitly create a spacing as a part of the scroll view.
-                    : SizedBox(height: isTopBarLayerAlwaysVisible ? 0 : topBarHeight);
+                    : SizedBox(
+                        height: isTopBarLayerAlwaysVisible ? 0 : topBarHeight);
               } else {
                 final pageTitle = page.pageTitle;
                 return KeyedSubtree(
@@ -98,17 +104,20 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     );
     return NotificationListener<ScrollNotification>(
       onNotification: (scrollNotification) {
-        final isVerticalScrollNotification = scrollNotification is ScrollUpdateNotification &&
-            scrollNotification.metrics.axis == Axis.vertical;
+        final isVerticalScrollNotification =
+            scrollNotification is ScrollUpdateNotification &&
+                scrollNotification.metrics.axis == Axis.vertical;
         if (isVerticalScrollNotification) {
-          widget.currentScrollPosition.value = scrollNotification.metrics.pixels;
+          widget.currentScrollPosition.value =
+              scrollNotification.metrics.pixels;
         }
         return false;
       },
       child: Padding(
         // The scroll view should be padded by the height of the top bar layer if it's always
         // visible. Otherwise, over scroll effect will not be visible due to the top bar layer.
-        padding: EdgeInsets.only(top: isTopBarLayerAlwaysVisible ? topBarHeight : 0),
+        padding:
+            EdgeInsets.only(top: isTopBarLayerAlwaysVisible ? topBarHeight : 0),
         child: scrollView,
       ),
     );

--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -45,20 +45,17 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     final page = widget.page;
     final heroImageHeight = page.heroImage == null
         ? 0.0
-        : (page.heroImageHeight ??
-            themeData?.heroImageHeight ??
-            defaultThemeData.heroImageHeight);
-    final pageHasTopBarLayer = page.hasTopBarLayer ??
-        themeData?.hasTopBarLayer ??
-        defaultThemeData.hasTopBarLayer;
-    final navBarHeight = page.navBarHeight ??
-        themeData?.navBarHeight ??
-        defaultThemeData.navBarHeight;
-    final topBarHeight = pageHasTopBarLayer ||
-            page.leadingNavBarWidget != null ||
-            page.trailingNavBarWidget != null
-        ? navBarHeight
-        : 0.0;
+        : (page.heroImageHeight ?? themeData?.heroImageHeight ?? defaultThemeData.heroImageHeight);
+    final pageHasTopBarLayer =
+        page.hasTopBarLayer ?? themeData?.hasTopBarLayer ?? defaultThemeData.hasTopBarLayer;
+    final isTopBarLayerAlwaysVisible =
+        pageHasTopBarLayer && page.isTopBarLayerAlwaysVisible == true;
+    final navBarHeight =
+        page.navBarHeight ?? themeData?.navBarHeight ?? defaultThemeData.navBarHeight;
+    final topBarHeight =
+        pageHasTopBarLayer || page.leadingNavBarWidget != null || page.trailingNavBarWidget != null
+            ? navBarHeight
+            : 0.0;
     final scrollView = CustomScrollView(
       scrollBehavior: const DragScrollBehavior(),
       shrinkWrap: true,
@@ -76,7 +73,10 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
                         heroImage: heroImage,
                         heroImageHeight: heroImageHeight,
                       )
-                    : SizedBox(height: topBarHeight);
+                    // If top bar layer is always visible, the padding is explicitly added to the
+                    // scroll view since top bar will not be integrated to scroll view at all.
+                    // Otherwise, we implicitly create a spacing as a part of the scroll view.
+                    : SizedBox(height: isTopBarLayerAlwaysVisible ? 0 : topBarHeight);
               } else {
                 final pageTitle = page.pageTitle;
                 return KeyedSubtree(
@@ -98,16 +98,19 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
     );
     return NotificationListener<ScrollNotification>(
       onNotification: (scrollNotification) {
-        final isVerticalScrollNotification =
-            scrollNotification is ScrollUpdateNotification &&
-                scrollNotification.metrics.axis == Axis.vertical;
+        final isVerticalScrollNotification = scrollNotification is ScrollUpdateNotification &&
+            scrollNotification.metrics.axis == Axis.vertical;
         if (isVerticalScrollNotification) {
-          widget.currentScrollPosition.value =
-              scrollNotification.metrics.pixels;
+          widget.currentScrollPosition.value = scrollNotification.metrics.pixels;
         }
         return false;
       },
-      child: scrollView,
+      child: Padding(
+        // The scroll view should be padded by the height of the top bar layer if it's always
+        // visible. Otherwise, over scroll effect will not be visible due to the top bar layer.
+        padding: EdgeInsets.only(top: isTopBarLayerAlwaysVisible ? topBarHeight : 0),
+        child: scrollView,
+      ),
     );
   }
 }

--- a/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
+++ b/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
@@ -33,26 +33,36 @@ class SheetPageWithDynamicPageProperties {
       leadingNavBarWidget:
           WoltModalSheetBackButton(onBackPressed: onBackPressed),
       trailingNavBarWidget: WoltModalSheetCloseButton(onClosed: onClosed),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 100),
-        child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-          return Row(
-            children: [
-              const Expanded(child: Text('Enable Drag for Bottom Sheet')),
-              Switch(
-                value: useOriginalPageValues,
-                onChanged: (newValue) {
-                  dynamicPageModel.value = dynamicPageModel.value.copyWith(
-                    enableDrag: newValue,
+      child: SingleChildScrollView(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) {
+                  return Row(
+                    children: [
+                      const Expanded(
+                          child: Text('Enable Drag for Bottom Sheet')),
+                      Switch(
+                        value: useOriginalPageValues,
+                        onChanged: (newValue) {
+                          dynamicPageModel.value =
+                              dynamicPageModel.value.copyWith(
+                            enableDrag: newValue,
+                          );
+                          setState(() =>
+                              useOriginalPageValues = !useOriginalPageValues);
+                        },
+                      ),
+                    ],
                   );
-                  setState(
-                      () => useOriginalPageValues = !useOriginalPageValues);
                 },
               ),
-            ],
-          );
-        }),
+            ),
+            const Placeholder(fallbackHeight: 1200, color: Colors.grey),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description
When the top bar is set to always visible, the overflow scroll effect from the leading side (top part) will not be visible since the custom scroll view is placed and starts behind the top bar.

This PR adds explicit padding to the custom scroll view when `isTopBarLayerAlwaysVisible` is set to `true`. 

This is how all the pages look after the fix:


https://github.com/woltapp/wolt_modal_sheet/assets/13782003/17304900-f7bc-468a-8815-98938db1df28





## Related Issues
* https://github.com/woltapp/wolt_modal_sheet/issues/102

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes tests for *all* changed/updated/fixed behaviors.
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [-] Yes, this is a breaking change.
- [-] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

