### PR TITLE
Fix drag handle width to allow interaction on top of main content

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -134,6 +134,7 @@ class _WoltModalSheetAnimatedSwitcherState
             woltModalType: widget.woltModalType,
             topBarTranslationY: _topBarTranslationY,
             showDragHandle: widget.showDragHandle,
+            sheetWidth: widget.sheetWidth,
           ),
         if (incomingWidgets != null)
           WoltModalSheetLayout(
@@ -142,6 +143,7 @@ class _WoltModalSheetAnimatedSwitcherState
             woltModalType: widget.woltModalType,
             topBarTranslationY: _topBarTranslationY,
             showDragHandle: widget.showDragHandle,
+            sheetWidth: widget.sheetWidth,
           ),
         if (incomingWidgets != null &&
             animationController != null &&

--- a/lib/src/content/wolt_modal_sheet_layout.dart
+++ b/lib/src/content/wolt_modal_sheet_layout.dart
@@ -35,7 +35,8 @@ class WoltModalSheetLayout extends StatelessWidget {
             themeData?.navBarHeight ??
             defaultThemeData.navBarHeight)
         : 0.0;
-    final handleWidth = (themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize).width;
+    final handleWidth =
+        (themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize).width;
     return Stack(
       children: [
         paginatingWidgetsGroup.mainContentAnimatedBuilder,

--- a/lib/src/content/wolt_modal_sheet_layout.dart
+++ b/lib/src/content/wolt_modal_sheet_layout.dart
@@ -12,6 +12,7 @@ class WoltModalSheetLayout extends StatelessWidget {
     required this.woltModalType,
     required this.topBarTranslationY,
     required this.showDragHandle,
+    required this.sheetWidth,
     Key? key,
   }) : super(key: key);
 
@@ -20,6 +21,7 @@ class WoltModalSheetLayout extends StatelessWidget {
   final WoltModalType woltModalType;
   final double topBarTranslationY;
   final bool showDragHandle;
+  final double sheetWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +35,7 @@ class WoltModalSheetLayout extends StatelessWidget {
             themeData?.navBarHeight ??
             defaultThemeData.navBarHeight)
         : 0.0;
+    final handleWidth = (themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize).width;
     return Stack(
       children: [
         paginatingWidgetsGroup.mainContentAnimatedBuilder,
@@ -45,11 +48,10 @@ class WoltModalSheetLayout extends StatelessWidget {
             child: paginatingWidgetsGroup.topBarAnimatedBuilder,
           ),
         if (showDragHandle)
-          const Positioned(
-            left: 0,
-            right: 0,
+          Positioned(
+            left: (sheetWidth - handleWidth) / 2,
             top: 0,
-            child: WoltBottomSheetDragHandle(),
+            child: const WoltBottomSheetDragHandle(),
           ),
         Positioned(
           top: 0,

--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -28,9 +28,11 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
       container: true,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        child: SizedBox(
-          width: _minInteractiveDimension,
-          height: _minInteractiveDimension,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minWidth: _minInteractiveDimension,
+            minHeight: _minInteractiveDimension,
+          ),
           child: Container(
             margin: EdgeInsets.fromLTRB(
               horizontalPadding,

--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -11,32 +11,35 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
-    final handleSize =
-        themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
-    final handleColor =
-        themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+    final handleSize = themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
+    final handleColor = themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+    const topPadding = 8.0;
+    final bottomPadding = _minInteractiveDimension - topPadding - handleSize.height;
+    final horizontalPadding = (_minInteractiveDimension - handleSize.width) / 2;
     return Semantics(
       label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       container: true,
-      child: SizedBox.square(
-        dimension: _minInteractiveDimension,
-        // By setting behavior to HitTestBehavior.opaque, the GestureDetector will capture touch
-        // events even if its child (the drag handle) isn't the exact size of the gesture.
-        // This will prevent the scrollable content below from receiving the touch events,
-        // effectively allowing the handler to capture drag gestures.
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: Container(
-              margin: const EdgeInsets.only(top: 8.0),
-              height: handleSize.height,
-              width: handleSize.width,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(handleSize.height / 2),
-                color: handleColor,
-              ),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        child: SizedBox.square(
+          dimension: _minInteractiveDimension,
+          // By setting behavior to HitTestBehavior.opaque, the GestureDetector will capture touch
+          // events even if its child (the drag handle) isn't the exact size of the gesture.
+          // This will prevent the scrollable content below from receiving the touch events,
+          // effectively allowing the handler to capture drag gestures.
+          child: Container(
+            margin: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              topPadding,
+              horizontalPadding,
+              bottomPadding,
             ),
+            decoration: BoxDecoration(
+              color: handleColor,
+              borderRadius: BorderRadius.circular(handleSize.height / 2),
+            ),
+            width: handleSize.width,
+            height: handleSize.height,
           ),
         ),
       ),

--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -13,33 +13,37 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
     final handleSize = themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
     final handleColor = themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+
+    // Ensure that handle size does not exceed the minimum interactive dimension.
+    final adjustedHandleWidth = handleSize.width.clamp(0.0, _minInteractiveDimension);
+    final adjustedHandleHeight = handleSize.height.clamp(0.0, _minInteractiveDimension);
+
+    // Calculate padding to center the handle.
+    final horizontalPadding = (_minInteractiveDimension - adjustedHandleWidth) / 2;
     const topPadding = 8.0;
-    final bottomPadding = _minInteractiveDimension - topPadding - handleSize.height;
-    final horizontalPadding = (_minInteractiveDimension - handleSize.width) / 2;
+    final bottomPadding = _minInteractiveDimension - topPadding - adjustedHandleHeight;
+
     return Semantics(
       label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       container: true,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        child: SizedBox.square(
-          dimension: _minInteractiveDimension,
-          // By setting behavior to HitTestBehavior.opaque, the GestureDetector will capture touch
-          // events even if its child (the drag handle) isn't the exact size of the gesture.
-          // This will prevent the scrollable content below from receiving the touch events,
-          // effectively allowing the handler to capture drag gestures.
+        child: SizedBox(
+          width: _minInteractiveDimension,
+          height: _minInteractiveDimension,
           child: Container(
             margin: EdgeInsets.fromLTRB(
               horizontalPadding,
               topPadding,
               horizontalPadding,
-              bottomPadding,
+              bottomPadding.clamp(0.0, _minInteractiveDimension),
             ),
             decoration: BoxDecoration(
               color: handleColor,
-              borderRadius: BorderRadius.circular(handleSize.height / 2),
+              borderRadius: BorderRadius.circular(adjustedHandleHeight / 2),
             ),
-            width: handleSize.width,
-            height: handleSize.height,
+            width: adjustedHandleWidth,
+            height: adjustedHandleHeight,
           ),
         ),
       ),

--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -11,17 +11,23 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
-    final handleSize = themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
-    final handleColor = themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+    final handleSize =
+        themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
+    final handleColor =
+        themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
 
     // Ensure that handle size does not exceed the minimum interactive dimension.
-    final adjustedHandleWidth = handleSize.width.clamp(0.0, _minInteractiveDimension);
-    final adjustedHandleHeight = handleSize.height.clamp(0.0, _minInteractiveDimension);
+    final adjustedHandleWidth =
+        handleSize.width.clamp(0.0, _minInteractiveDimension);
+    final adjustedHandleHeight =
+        handleSize.height.clamp(0.0, _minInteractiveDimension);
 
     // Calculate padding to center the handle.
-    final horizontalPadding = (_minInteractiveDimension - adjustedHandleWidth) / 2;
+    final horizontalPadding =
+        (_minInteractiveDimension - adjustedHandleWidth) / 2;
     const topPadding = 8.0;
-    final bottomPadding = _minInteractiveDimension - topPadding - adjustedHandleHeight;
+    final bottomPadding =
+        _minInteractiveDimension - topPadding - adjustedHandleHeight;
 
     return Semantics(
       label: MaterialLocalizations.of(context).modalBarrierDismissLabel,


### PR DESCRIPTION
## Description

This PR fixes the issue https://github.com/woltapp/wolt_modal_sheet/issues/105

Currently, the drag handle width is set to expand the entire width resulting in blocking the interaction on top of the main content. This PR removes the Align alignment inside the BottomSheetHandler causing this bug, and utilizes the Positioned widget correctly centering the handler.

| Before  | After |
| ------------- | ------------- |
| ![sheet_handle_broken](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/c89161f9-f82d-4a2f-a140-18a3f0007a85) | ![sheet_handle_fixed](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/1bdfd9f7-1d58-45d5-b4e3-1592d636867e) |

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/woltapp/wolt_modal_sheet/issues). Indicate, which of these issues are resolved or fixed by this PR.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

