### PR TITLE
Fix 'No MaterialLocalizations found' exception for Cupertino apps

### DIFF
--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -12,8 +12,10 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
-    final handleSize = themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
-    final handleColor = themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+    final handleSize =
+        themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
+    final handleColor =
+        themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
     return Semantics(
       label: semanticsLabel(context),
       container: true,
@@ -43,9 +45,11 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
   }
 
   String semanticsLabel(BuildContext context) {
-    return Localizations.of<MaterialLocalizations>(context, MaterialLocalizations)
+    return Localizations.of<MaterialLocalizations>(
+                context, MaterialLocalizations)
             ?.modalBarrierDismissLabel ??
-        Localizations.of<CupertinoLocalizations>(context, CupertinoLocalizations)
+        Localizations.of<CupertinoLocalizations>(
+                context, CupertinoLocalizations)
             ?.modalBarrierDismissLabel ??
         const DefaultMaterialLocalizations().modalBarrierDismissLabel;
   }

--- a/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
+++ b/lib/src/widgets/wolt_bottom_sheet_drag_handle.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/theme/wolt_modal_sheet_default_theme_data.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
@@ -11,12 +12,10 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
-    final handleSize =
-        themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
-    final handleColor =
-        themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
+    final handleSize = themeData?.dragHandleSize ?? defaultThemeData.dragHandleSize;
+    final handleColor = themeData?.dragHandleColor ?? defaultThemeData.dragHandleColor;
     return Semantics(
-      label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      label: semanticsLabel(context),
       container: true,
       child: SizedBox.square(
         dimension: _minInteractiveDimension,
@@ -41,5 +40,13 @@ class WoltBottomSheetDragHandle extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String semanticsLabel(BuildContext context) {
+    return Localizations.of<MaterialLocalizations>(context, MaterialLocalizations)
+            ?.modalBarrierDismissLabel ??
+        Localizations.of<CupertinoLocalizations>(context, CupertinoLocalizations)
+            ?.modalBarrierDismissLabel ??
+        const DefaultMaterialLocalizations().modalBarrierDismissLabel;
   }
 }


### PR DESCRIPTION
## Description
We are trying to read `MaterialLocalizations.of(context).modalBarrierDismissLabel` which is not there for Cupertino apps. In this fix;
- We first try to read it from `MaterialLocalizations`,
- If not available, try to read it from `CupertinoLocalizations`,
- If that is also not available, return the default label from `DefaultMaterialLocalizations`.

Note: Test cases will be added after we decide which mocking package to use.

## Related Issues
https://github.com/woltapp/wolt_modal_sheet/issues/61

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

