### PR TITLE
Fix `RangeError` on the `SheetPageWithLazyList` of the `playground_navigator2 `.

### DIFF
--- a/playground_navigator2/lib/modal/pages/sheet_page_with_lazy_list.dart
+++ b/playground_navigator2/lib/modal/pages/sheet_page_with_lazy_list.dart
@@ -44,7 +44,7 @@ class SheetPageWithLazyList {
               if (index == 0) {
                 return const _HorizontalPrimaryColorList();
               }
-              return ColorTile(color: colors[index]);
+              return ColorTile(color: colors[index - 1]);
             },
             childCount: colors.length + 1,
           ),


### PR DESCRIPTION
## Description

This PR fixes a `RangeError` appearing on the `SheetPageWithLazyList` of the `playground_navigator2 `.

## Related Issues

Fixes: https://github.com/woltapp/wolt_modal_sheet/issues/117

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

