### PR TITLE
[Issue-96] Fix TopBar Widget keeps being visible after Keyboard hides

### DIFF
--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -7,14 +7,14 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 ///
 /// This widget is responsible for displaying the main content of the scrollable modal sheet.
 /// It handles the scroll behavior, page layout, and interactions within the modal sheet.
-class WoltModalSheetMainContent extends StatefulWidget {
-  final ValueNotifier<double> currentScrollPosition;
+class WoltModalSheetMainContent extends StatelessWidget {
+  final ScrollController? scrollController;
   final GlobalKey pageTitleKey;
   final SliverWoltModalSheetPage page;
   final WoltModalType woltModalType;
 
   const WoltModalSheetMainContent({
-    required this.currentScrollPosition,
+    required this.scrollController,
     required this.pageTitleKey,
     required this.page,
     required this.woltModalType,
@@ -22,26 +22,9 @@ class WoltModalSheetMainContent extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<WoltModalSheetMainContent> createState() =>
-      _WoltModalSheetMainContentState();
-}
-
-class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
-  late ScrollController scrollController;
-
-  @override
-  void initState() {
-    super.initState();
-    scrollController = widget.page.scrollController ??
-        ScrollController(
-            initialScrollOffset: widget.currentScrollPosition.value);
-  }
-
-  @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
-    final page = widget.page;
     final heroImageHeight = page.heroImage == null
         ? 0.0
         : (page.heroImageHeight ??
@@ -85,7 +68,7 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
               } else {
                 final pageTitle = page.pageTitle;
                 return KeyedSubtree(
-                  key: widget.pageTitleKey,
+                  key: pageTitleKey,
                   child: pageTitle ?? const SizedBox.shrink(),
                 );
               }
@@ -101,24 +84,12 @@ class _WoltModalSheetMainContentState extends State<WoltModalSheetMainContent> {
           ),
       ],
     );
-    return NotificationListener<ScrollNotification>(
-      onNotification: (scrollNotification) {
-        final isVerticalScrollNotification =
-            scrollNotification is ScrollUpdateNotification &&
-                scrollNotification.metrics.axis == Axis.vertical;
-        if (isVerticalScrollNotification) {
-          widget.currentScrollPosition.value =
-              scrollNotification.metrics.pixels;
-        }
-        return false;
-      },
-      child: Padding(
-        // The scroll view should be padded by the height of the top bar layer if it's always
-        // visible. Otherwise, over scroll effect will not be visible due to the top bar layer.
-        padding:
-            EdgeInsets.only(top: isTopBarLayerAlwaysVisible ? topBarHeight : 0),
-        child: scrollView,
-      ),
+    return Padding(
+      // The scroll view should be padded by the height of the top bar layer if it's always
+      // visible. Otherwise, over scroll effect will not be visible due to the top bar layer.
+      padding:
+          EdgeInsets.only(top: isTopBarLayerAlwaysVisible ? topBarHeight : 0),
+      child: scrollView,
     );
   }
 }

--- a/lib/src/content/components/main_content/wolt_modal_sheet_top_bar_title_flow.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_top_bar_title_flow.dart
@@ -1,21 +1,30 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/theme/wolt_modal_sheet_default_theme_data.dart';
+import 'package:wolt_modal_sheet/src/utils/soft_keyboard_closed_event.dart';
 import 'package:wolt_modal_sheet/src/utils/wolt_layout_transformation_utils.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
-/// This class represents the top bar title behavior within a modal sheet page.
+/// [WoltModalSheetTopBarTitleFlow] controls the top bar title behavior within the modal sheet page
+/// provided by the [WoltModalSheetPage] when `isTopBarLayerAlwaysVisible` is set to false.
+///
+/// It is responsible for the positioning, translation, and opacity of the top bar title as the user
+/// scrolls through the content. Utilizing the [Flow] widget, it listens to the current scroll
+/// position and soft keyboard closing events, then, performs transformations to achieve the
+/// desired  effects on the top bar title, such as fading in/out and translating vertically.
 class WoltModalSheetTopBarTitleFlow extends StatelessWidget {
-  final ValueListenable<double> currentScrollPositionListenable;
+  final ScrollController scrollController;
   final GlobalKey titleKey;
   final SliverWoltModalSheetPage page;
   final Widget topBarTitle;
+  final ValueListenable<SoftKeyboardClosedEvent> softKeyboardClosedListenable;
 
   const WoltModalSheetTopBarTitleFlow({
     required this.page,
-    required this.currentScrollPositionListenable,
+    required this.scrollController,
     required this.titleKey,
     required this.topBarTitle,
+    required this.softKeyboardClosedListenable,
     Key? key,
   }) : super(key: key);
 
@@ -37,9 +46,9 @@ class WoltModalSheetTopBarTitleFlow extends StatelessWidget {
       delegate: _TopBarTitleFlowDelegate(
         topBarHeight: topBarHeight,
         heroImageHeight: heroImageHeight,
-        currentScrollPositionListenable: currentScrollPositionListenable,
+        scrollController: scrollController,
         titleKey: titleKey,
-        buildContext: context,
+        softKeyboardClosedNotifier: softKeyboardClosedListenable,
       ),
       children: [Center(child: topBarTitle)],
     );
@@ -49,19 +58,24 @@ class WoltModalSheetTopBarTitleFlow extends StatelessWidget {
 class _TopBarTitleFlowDelegate extends FlowDelegate {
   final double topBarHeight;
   final double heroImageHeight;
-  final ValueListenable<double> currentScrollPositionListenable;
+  final ScrollController scrollController;
   final GlobalKey titleKey;
-  final BuildContext buildContext;
+  final ValueListenable<SoftKeyboardClosedEvent> softKeyboardClosedNotifier;
 
   _TopBarTitleFlowDelegate({
     required this.topBarHeight,
     required this.heroImageHeight,
-    required this.currentScrollPositionListenable,
+    required this.scrollController,
     required this.titleKey,
-    required this.buildContext,
-  }) : super(repaint: currentScrollPositionListenable);
+    required this.softKeyboardClosedNotifier,
+  }) : super(
+          repaint: Listenable.merge([
+            scrollController,
+            softKeyboardClosedNotifier,
+          ]),
+        );
 
-  double get currentScrollPosition => currentScrollPositionListenable.value;
+  double get currentScrollPosition => scrollController.position.pixels;
 
   @override
   void paintChildren(FlowPaintingContext context) {
@@ -108,7 +122,10 @@ class _TopBarTitleFlowDelegate extends FlowDelegate {
   bool shouldRepaint(covariant _TopBarTitleFlowDelegate oldDelegate) {
     return heroImageHeight != oldDelegate.heroImageHeight ||
         titleKey != oldDelegate.titleKey ||
-        currentScrollPosition != oldDelegate.currentScrollPosition ||
+        scrollController.position.pixels !=
+            oldDelegate.scrollController.position.pixels ||
+        softKeyboardClosedNotifier.value !=
+            oldDelegate.softKeyboardClosedNotifier.value ||
         topBarHeight != oldDelegate.topBarHeight;
   }
 }

--- a/lib/src/utils/soft_keyboard_closed_event.dart
+++ b/lib/src/utils/soft_keyboard_closed_event.dart
@@ -1,0 +1,7 @@
+/// An event representing the closing of the soft keyboard. Each event has a unique ID.
+class SoftKeyboardClosedEvent {
+  /// The unique ID of the event.
+  final int eventId;
+
+  const SoftKeyboardClosedEvent({required this.eventId});
+}

--- a/playground/lib/home/pages/sheet_page_with_text_field.dart
+++ b/playground/lib/home/pages/sheet_page_with_text_field.dart
@@ -34,8 +34,8 @@ class SheetPageWithTextField {
           );
         },
       ),
+      pageTitle: const ModalSheetTitle('Page with text field'),
       topBarTitle: const ModalSheetTopBarTitle('Page with text field'),
-      isTopBarLayerAlwaysVisible: true,
       leadingNavBarWidget:
           WoltModalSheetBackButton(onBackPressed: onBackPressed),
       trailingNavBarWidget: WoltModalSheetCloseButton(onClosed: onClosed),
@@ -45,6 +45,10 @@ class SheetPageWithTextField {
         child: Column(
           children: [
             const ModalSheetContentText('''
+This page has a text field and always visible top bar title. We wait for the keyboard closing before starting pagination. Don't forget to add a scroll padding to your text field to avoid the keyboard hiding the text field.
+\n\n
+This page has a text field and always visible top bar title. We wait for the keyboard closing before starting pagination. Don't forget to add a scroll padding to your text field to avoid the keyboard hiding the text field.
+\n\n
 This page has a text field and always visible top bar title. We wait for the keyboard closing before starting pagination. Don't forget to add a scroll padding to your text field to avoid the keyboard hiding the text field.
 '''),
             Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_keyboard_visibility: ">=6.0.0"
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Description

This PR fixes the top bar widget visibility issue due to keyboard closing event (#96) by introducing a new feature in the form of a value notifier, specifically designed to detect the dismissal of the soft-keyboard. This PR primarily impacts two components: `WoltModalSheetTopBarFlow` and `WoltModalSheetTopBarTitleFlow`.

## Key points

### Purpose 
The primary goal of this implementation is to trigger a re-paint in the top bar components when the soft-keyboard is closed. This is essential to prevent the top bar from being stuck unresponsive after the keyboard's closing phase.

### Default Behavior Sync with Scroll Controller
When `isTopBarAlwaysVisible` is set to false (by default), the visibility and appearance of the top bar and top bar title are synchronized with the scroll controller's position. Both `WoltModalSheetTopBarFlow` and `WoltModalSheetTopBarTitleFlow` use the scroll position data to determine how the top bar should be painted.

### Challenge with Keyboard Events
While the appearance of the soft-keyboard naturally triggers scroll update events (courtesy of the Flutter SDK), its dismissal does not inherently cause a similar update in the scroll controller. This discrepancy leads to a situation where the top bar does not repaint as expected when the keyboard closes.

### Solution
To address this, the implemented value notifier actively detects the dismissal of the keyboard. Upon this event, it manually triggers a repaint for the top bar flow and top bar title flow widgets. This ensures that the top bar refreshes its state appropriately, maintaining a smooth and responsive user interface.

## Additional Changes
* `NotificationController` widget inside the `WoltModalSheetMainContent` is removed since the scroll position is listened directly from the scroll controllers inside `WoltModalSheetAnimatedSwitcher` widget.
* Unnecessary passing of the `BuildContext` to flow delegates is removed.

## Screenshots
| Before | After |
|--------|--------|
|  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/b12e3ea5-40cf-4b63-b7c6-4581e743ed45"> |  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/82955e33-c098-4a8b-8703-6f60b766dafd"> |
 


## Related Issues
#96 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change. The users of this package should set their [flutter_keyboard_visibility](https://pub.dev/packages/flutter_keyboard_visibility) package version to minimum `6.0.0`.
- [] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

