### PR TITLE
Convert MaterialApp example app to CupertinoApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,18 @@ SliverWoltModalSheetPage(mainContentSlivers: [MySliverList1(), MySliverList2()])
 To use this plugin, add wolt_modal_sheet as a dependency in your pubspec.yaml
 file.
 
+## Cupertino support
+
+If you are using `CupertinoApp` instead of `MaterialApp`, please add default material localization delegate to your app:
+
+```dart
+CupertinoApp(
+  localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+    DefaultMaterialLocalizations.delegate,
+],)
+```
+To see its usage, please check [coffee maker example app](coffee_maker/lib/main.dart).
+
 ## Usage
 
 This package has 4 example projects.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ file.
 ## CupertinoApp support
 
 Some Material widgets that we use in the package reads material localisations information from the widget tree.
-Since, material localisations are not available in CupertinoApp by default, it causes an error. To prevent that;
+Since, Material localisations are not available in `CupertinoApp` by default, it causes an error. To prevent that;
 if you are using `CupertinoApp` instead of `MaterialApp`, please add default material localization
 delegate to your app:
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,12 @@ SliverWoltModalSheetPage(mainContentSlivers: [MySliverList1(), MySliverList2()])
 To use this plugin, add wolt_modal_sheet as a dependency in your pubspec.yaml
 file.
 
-## Cupertino support
+## CupertinoApp support
 
-If you are using `CupertinoApp` instead of `MaterialApp`, please add default material localization delegate to your app:
+Some Material widgets that we use in the package reads material localisations information from the widget tree.
+Since, material localisations are not available in CupertinoApp by default, it causes an error. To prevent that;
+if you are using `CupertinoApp` instead of `MaterialApp`, please add default material localization
+delegate to your app:
 
 ```dart
 CupertinoApp(

--- a/README.md
+++ b/README.md
@@ -291,10 +291,11 @@ file.
 
 ## CupertinoApp support
 
-Some Material widgets that we use in the package reads material localisations information from the widget tree.
-Since, Material localisations are not available in `CupertinoApp` by default, it causes an error. To prevent that;
-if you are using `CupertinoApp` instead of `MaterialApp`, please add default material localization
-delegate to your app:
+In the package, certain Material widgets rely on retrieving Material localizations information
+from the widget tree. However, Material localizations are not inherently available in CupertinoApp,
+leading to potential errors. To mitigate this issue, if your application utilizes CupertinoApp
+rather than MaterialApp, it is needed to incorporate a default Material localization delegate
+into your application configuration.
 
 ```dart
 CupertinoApp(

--- a/coffee_maker/lib/home/online/widgets/coffee_order_list_item_tile.dart
+++ b/coffee_maker/lib/home/online/widgets/coffee_order_list_item_tile.dart
@@ -100,10 +100,8 @@ class _CoffeeOrderListItemDetails extends StatelessWidget {
           onPressed: _onTap,
           child: Text(
             _coffeeOrder.id,
-            style: Theme.of(context)
-                .textTheme
-                .headlineSmall!
-                .copyWith(fontWeight: FontWeight.bold, color: DemoAppColors.black),
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
+                fontWeight: FontWeight.bold, color: DemoAppColors.black),
           ),
         ),
         const SizedBox(width: 8),

--- a/coffee_maker/lib/home/online/widgets/coffee_order_list_item_tile.dart
+++ b/coffee_maker/lib/home/online/widgets/coffee_order_list_item_tile.dart
@@ -103,7 +103,7 @@ class _CoffeeOrderListItemDetails extends StatelessWidget {
             style: Theme.of(context)
                 .textTheme
                 .headlineSmall!
-                .copyWith(fontWeight: FontWeight.bold),
+                .copyWith(fontWeight: FontWeight.bold, color: DemoAppColors.black),
           ),
         ),
         const SizedBox(width: 8),

--- a/coffee_maker/lib/main.dart
+++ b/coffee_maker/lib/main.dart
@@ -86,15 +86,18 @@ class _DemoAppState extends State<DemoApp> {
           ),
           outlinedButtonTheme: OutlinedButtonThemeData(
             style: OutlinedButton.styleFrom(
-              textStyle:
-                  Theme.of(context).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
+              textStyle: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(fontWeight: FontWeight.bold),
               foregroundColor: DemoAppColors.black,
               backgroundColor: DemoAppColors.white,
               surfaceTintColor: DemoAppColors.white,
               fixedSize: const Size.fromHeight(36),
               padding: const EdgeInsets.all(12),
               visualDensity: VisualDensity.compact,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
               side: BorderSide.none,
             ),
           ),
@@ -117,7 +120,8 @@ class _DemoAppState extends State<DemoApp> {
           ),
         ),
         child: HomeScreen(
-          groupedCoffeeOrders: GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
+          groupedCoffeeOrders:
+              GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
           isStoreOnline: true,
           isGridOverlayVisible: false,
         ),

--- a/coffee_maker/lib/main.dart
+++ b/coffee_maker/lib/main.dart
@@ -36,6 +36,8 @@ class _DemoAppState extends State<DemoApp> {
   @override
   Widget build(BuildContext context) {
     return CupertinoApp(
+      // This is needed to make the app working with CupertinoApp.
+      // For more details on CupertinoApp support, see the "CupertinoApp Support" section in the README file.
       localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
         DefaultMaterialLocalizations.delegate,
       ],
@@ -86,18 +88,15 @@ class _DemoAppState extends State<DemoApp> {
           ),
           outlinedButtonTheme: OutlinedButtonThemeData(
             style: OutlinedButton.styleFrom(
-              textStyle: Theme.of(context)
-                  .textTheme
-                  .bodyMedium!
-                  .copyWith(fontWeight: FontWeight.bold),
+              textStyle:
+                  Theme.of(context).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
               foregroundColor: DemoAppColors.black,
               backgroundColor: DemoAppColors.white,
               surfaceTintColor: DemoAppColors.white,
               fixedSize: const Size.fromHeight(36),
               padding: const EdgeInsets.all(12),
               visualDensity: VisualDensity.compact,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8)),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
               side: BorderSide.none,
             ),
           ),
@@ -120,8 +119,7 @@ class _DemoAppState extends State<DemoApp> {
           ),
         ),
         child: HomeScreen(
-          groupedCoffeeOrders:
-              GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
+          groupedCoffeeOrders: GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
           isStoreOnline: true,
           isGridOverlayVisible: false,
         ),

--- a/coffee_maker/lib/main.dart
+++ b/coffee_maker/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:coffee_maker/entities/grouped_coffee_orders.dart';
 import 'package:coffee_maker/entities/mock_coffee_orders.dart';
 import 'package:coffee_maker/home/home_screen.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -34,91 +35,91 @@ class _DemoAppState extends State<DemoApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return CupertinoApp(
+      localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+      ],
       scrollBehavior: const CustomScrollBehavior(),
-      theme: ThemeData(
-        primaryColor: DemoAppColors.blue,
-        useMaterial3: true,
-        fontFamily: 'Inter',
-        inputDecorationTheme: const InputDecorationTheme(
-          suffixStyle: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w400,
-            color: DemoAppColors.black64,
-          ),
-          contentPadding: EdgeInsetsDirectional.fromSTEB(16, 12, 16, 8),
-          border: UnderlineInputBorder(borderSide: BorderSide.none),
-          constraints: BoxConstraints(minHeight: 64),
-          focusedBorder: OutlineInputBorder(
-            borderSide: BorderSide(color: WoltColors.blue),
-            borderRadius: BorderRadius.all(Radius.circular(8)),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderSide: BorderSide(color: WoltColors.black16),
-            borderRadius: BorderRadius.all(Radius.circular(8)),
-          ),
-          focusColor: WoltColors.blue,
-        ),
-        textTheme: TextTheme(
-          headlineMedium: TextStyle(
-            fontSize: 28,
-            fontWeight: FontWeight.w800,
-            letterSpacing: kIsWeb || Platform.isAndroid ? 0.2 : 0.12,
-          ),
-        ),
-        typography: Typography.material2021(platform: defaultTargetPlatform),
-        scaffoldBackgroundColor: DemoAppColors.white,
-        indicatorColor: Colors.transparent,
-        cardColor: DemoAppColors.white,
-        cardTheme: CardTheme(
-          elevation: 2,
-          color: DemoAppColors.white,
-          surfaceTintColor: DemoAppColors.white,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-        outlinedButtonTheme: OutlinedButtonThemeData(
-          style: OutlinedButton.styleFrom(
-            textStyle: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(fontWeight: FontWeight.bold),
-            foregroundColor: DemoAppColors.black,
-            backgroundColor: DemoAppColors.white,
-            surfaceTintColor: DemoAppColors.white,
-            fixedSize: const Size.fromHeight(36),
-            padding: const EdgeInsets.all(12),
-            visualDensity: VisualDensity.compact,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-            side: BorderSide.none,
-          ),
-        ),
-        navigationBarTheme: NavigationBarThemeData(
-          height: 56,
-          surfaceTintColor: Colors.transparent,
-          backgroundColor: DemoAppColors.white,
-          indicatorColor: Colors.transparent,
-          labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
-          labelTextStyle: MaterialStateProperty.resolveWith<TextStyle>(
-            (state) {
-              return TextStyle(
-                fontSize: 10,
-                color: state.contains(MaterialState.selected)
-                    ? DemoAppColors.blue
-                    : DemoAppColors.black64,
-              );
-            },
-          ),
-        ),
-      ),
       debugShowCheckedModeBanner: false,
-      home: HomeScreen(
-        groupedCoffeeOrders:
-            GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
-        isStoreOnline: true,
-        isGridOverlayVisible: false,
+      home: Theme(
+        data: Theme.of(context).copyWith(
+          primaryColor: DemoAppColors.blue,
+          useMaterial3: true,
+          inputDecorationTheme: const InputDecorationTheme(
+            suffixStyle: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+              color: DemoAppColors.black64,
+            ),
+            contentPadding: EdgeInsetsDirectional.fromSTEB(16, 12, 16, 8),
+            border: UnderlineInputBorder(borderSide: BorderSide.none),
+            constraints: BoxConstraints(minHeight: 64),
+            focusedBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: WoltColors.blue),
+              borderRadius: BorderRadius.all(Radius.circular(8)),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: WoltColors.black16),
+              borderRadius: BorderRadius.all(Radius.circular(8)),
+            ),
+            focusColor: WoltColors.blue,
+          ),
+          textTheme: TextTheme(
+            headlineMedium: TextStyle(
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              letterSpacing: kIsWeb || Platform.isAndroid ? 0.2 : 0.12,
+            ),
+          ),
+          typography: Typography.material2021(platform: defaultTargetPlatform),
+          scaffoldBackgroundColor: DemoAppColors.white,
+          indicatorColor: Colors.transparent,
+          cardColor: DemoAppColors.white,
+          cardTheme: CardTheme(
+            elevation: 2,
+            color: DemoAppColors.white,
+            surfaceTintColor: DemoAppColors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          outlinedButtonTheme: OutlinedButtonThemeData(
+            style: OutlinedButton.styleFrom(
+              textStyle:
+                  Theme.of(context).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
+              foregroundColor: DemoAppColors.black,
+              backgroundColor: DemoAppColors.white,
+              surfaceTintColor: DemoAppColors.white,
+              fixedSize: const Size.fromHeight(36),
+              padding: const EdgeInsets.all(12),
+              visualDensity: VisualDensity.compact,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              side: BorderSide.none,
+            ),
+          ),
+          navigationBarTheme: NavigationBarThemeData(
+            height: 56,
+            surfaceTintColor: Colors.transparent,
+            backgroundColor: DemoAppColors.white,
+            indicatorColor: Colors.transparent,
+            labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+            labelTextStyle: MaterialStateProperty.resolveWith<TextStyle>(
+              (state) {
+                return TextStyle(
+                  fontSize: 10,
+                  color: state.contains(MaterialState.selected)
+                      ? DemoAppColors.blue
+                      : DemoAppColors.black64,
+                );
+              },
+            ),
+          ),
+        ),
+        child: HomeScreen(
+          groupedCoffeeOrders: GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
+          isStoreOnline: true,
+          isGridOverlayVisible: false,
+        ),
       ),
     );
   }

--- a/coffee_maker/lib/main.dart
+++ b/coffee_maker/lib/main.dart
@@ -88,15 +88,18 @@ class _DemoAppState extends State<DemoApp> {
           ),
           outlinedButtonTheme: OutlinedButtonThemeData(
             style: OutlinedButton.styleFrom(
-              textStyle:
-                  Theme.of(context).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
+              textStyle: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(fontWeight: FontWeight.bold),
               foregroundColor: DemoAppColors.black,
               backgroundColor: DemoAppColors.white,
               surfaceTintColor: DemoAppColors.white,
               fixedSize: const Size.fromHeight(36),
               padding: const EdgeInsets.all(12),
               visualDensity: VisualDensity.compact,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8)),
               side: BorderSide.none,
             ),
           ),
@@ -119,7 +122,8 @@ class _DemoAppState extends State<DemoApp> {
           ),
         ),
         child: HomeScreen(
-          groupedCoffeeOrders: GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
+          groupedCoffeeOrders:
+              GroupedCoffeeOrders.fromCoffeeOrders(mockCoffeeOrders),
           isStoreOnline: true,
           isGridOverlayVisible: false,
         ),

--- a/coffee_maker/lib/main.dart
+++ b/coffee_maker/lib/main.dart
@@ -67,6 +67,7 @@ class _DemoAppState extends State<DemoApp> {
           textTheme: TextTheme(
             headlineMedium: TextStyle(
               fontSize: 28,
+              color: DemoAppColors.black,
               fontWeight: FontWeight.w800,
               letterSpacing: kIsWeb || Platform.isAndroid ? 0.2 : 0.12,
             ),


### PR DESCRIPTION
## Description

Our all example apps are uses `MaterialApp` at the top level, we are switching to `CupertinoApp` in `coffee_maker` example to also demonstrate that.

Before | After
:-:| :-:
<video src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/f2801497-e255-4dfe-a8bd-97a48624a680 width=180/> | <video src=https://github.com/woltapp/wolt_modal_sheet/assets/7239330/5994ee7f-1ec7-4aef-9b5b-05572d88c4fd width=180/>


## Related Issues
https://github.com/woltapp/wolt_modal_sheet/issues/61

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

