### PR TITLE
Fix state update handling: Current page widgets do not receive update if the decorator marks the page as dirty

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -193,6 +193,14 @@ class _WoltModalSheetAnimatedSwitcherState
     }
     if (oldWidget.pageIndex != widget.pageIndex) {
       _addPage(animate: true);
+    } else {
+      // In this case, the page index didn't change and there is no pagination animation needed,
+      // but all the widgets inside the page should be marked as dirty to receive the updates. We
+      // are aware that this is not the most efficient way to handle this problem. There
+      // is a planned complete internal refactor for performance improvements and address this
+      // issue.
+      _incomingPageWidgets = null;
+      _addPage(animate: false);
     }
   }
 


### PR DESCRIPTION
## Description

This Pull Request introduces an improvement to the state management within the WoltModalSheet package. Specifically, it addresses the scenario where the state update does not reflect on the modal sheet page due to unchanged page index yet with a new widget set provided.

## Issue and Solution

Previously, when the root decorator widget, typically utilized as a ChangeNotifierProvider, updated the state, the new set of widgets associated with the same page index did not update the UI as expected. This was because the internal mechanism did not adequately mark the new widget set as "dirty" for rendering.

To resolve this, the PR implements a strategy where the incoming widget set is explicitly set to null following a state change. Subsequently, it forcibly rebuilds the current page set with the updated widgets. This ensures that the new state is accurately represented on the modal sheet page, even when the page index remains constant.

## Impact

This change ensures that the UI reflects the current state without requiring a page index change. This enhancement is particularly crucial for applications where modal sheet content dynamically updates based on user interaction or other state changes without navigation between pages.

## Performance Considerations

While this fix ensures the correctness of the UI, it is acknowledged that setting the widget set to null and rebuilding the entire page is not the most efficient approach. There is a planned comprehensive internal refactor to improve performance and address this inefficiency.

Testing

This change has been manually tested to ensure that the widget set updates correctly without requiring a page index change. Automated tests will be developed as part of the planned refactor to ensure no regression in the future.

| Before | After |
|--------|--------|
|  <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/d9c9f557-3ee0-46d5-8267-af2112e67e57"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/d10c0ee4-b78d-4059-8c32-82a8fe73de24"> | 


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

