### PR TITLE
Update hero image in the pub dev example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,8 +96,8 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
           ),
         ),
         heroImage: Image(
-          image: AssetImage(
-            'lib/assets/images/material_colors_hero${_isLightTheme ? '_light' : '_dark'}.png',
+          image: NetworkImage(
+            'https://raw.githubusercontent.com/woltapp/wolt_modal_sheet/main/example/lib/assets/images/material_colors_hero${_isLightTheme ? '_light' : '_dark'}.png',
           ),
           fit: BoxFit.cover,
         ),


### PR DESCRIPTION
## Description

Issue reported within #91

If we copied the `wolt_modal_bottom` sheet directly instead of cloning the example from `pub.dev`, an error would occur because we did not import the assets but only the code. That's why I decided to pull the example from the `github repo` instead of getting the `assets` from local. (This bug was solved before, but I solved it again because it did not fit the guidle.)


<p align="center">
  <table>
    <tr>
      <th style="text-align: center">Error</th>
      <th style="text-align: center">Fixed</th>
    </tr>
    <tr>
      <td style="text-align: center">
        <img src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/1a58ed1c-e389-4627-bff1-296119373844" alt="Error" width="400" />
      </td>
      <td style="text-align: center">
        <img src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/2a033d0f-6802-4907-a3b2-d31ff6647310" alt="Fixed" width="400" />
      </td>
    </tr>
  </table>
</p>



## Related Issues

fix #91

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

