### PR TITLE
Revert "fix-page-widgets-not-marked-as-dirty-when-decorator-updates"

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -193,14 +193,6 @@ class _WoltModalSheetAnimatedSwitcherState
     }
     if (oldWidget.pageIndex != widget.pageIndex) {
       _addPage(animate: true);
-    } else {
-      // In this case, the page index didn't change and there is no pagination animation needed,
-      // but all the widgets inside the page should be marked as dirty to receive the updates. We
-      // are aware that this is not the most efficient way to handle this problem. There
-      // is a planned complete internal refactor for performance improvements and address this
-      // issue.
-      _incomingPageWidgets = null;
-      _addPage(animate: false);
     }
   }
 


### PR DESCRIPTION
This reverts commit 002f2c2a97f1c6dd32df04f2d6342bae731bc048.

This PR revert addresses the issues #134 #135 