### PR TITLE
Refactor deprecated location code

### DIFF
--- a/playground_navigator2/lib/router/playground_route_information_parser.dart
+++ b/playground_navigator2/lib/router/playground_route_information_parser.dart
@@ -13,7 +13,8 @@ class PlaygroundRouteInformationParser
   @override
   Future<PlaygroundRouterConfiguration> parseRouteInformation(
       RouteInformation routeInformation) async {
-    final uri = Uri.parse(routeInformation.location!);
+    final uri = routeInformation.uri;
+
     if (uri.pathSegments.isEmpty) {
       return PlaygroundRouterConfiguration.home();
     } else if (uri.pathSegments.length == 1) {
@@ -54,15 +55,15 @@ class PlaygroundRouteInformationParser
   RouteInformation? restoreRouteInformation(
       PlaygroundRouterConfiguration configuration) {
     if (configuration.isUnknown) {
-      return const RouteInformation(location: '/unknown');
+      return RouteInformation(uri: Uri.parse('/unknown'));
     } else if (configuration.isHomePage) {
-      return const RouteInformation(location: '/');
+      return RouteInformation(uri: Uri.parse('/'));
     } else if (configuration.isSheetPage) {
       final path = configuration.multiPagePathName?.queryParamName;
       final pageIndex = configuration.pageIndex;
       return RouteInformation(
-        location:
-            '/$sheetPageSegment?$pathQueryParam=$path&$pageIndexQueryParam=$pageIndex',
+        uri: Uri.parse(
+            '/$sheetPageSegment?$pathQueryParam=$path&$pageIndexQueryParam=$pageIndex'),
       );
     } else {
       return null;


### PR DESCRIPTION
## Description

Since the location parameter was deprecated, I passed it to the uri parameter.

## Related Issues

fix #145 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

