### PR TITLE
Change Default Clip Behavior to antiAliasWithSaveLayer to fix Top Bar rendering issue

### DIFF
--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -148,7 +148,7 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
 
   /// Overrides the default value for [WoltModalSheet] clipBehavior.
   ///
-  /// If null, [WoltModalSheet] uses [Clip.none].
+  /// If null, [WoltModalSheet] uses [Clip.antiAliasWithSaveLayer].
   @override
-  Clip get clipBehavior => Clip.antiAlias;
+  Clip get clipBehavior => Clip.antiAliasWithSaveLayer;
 }

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -148,7 +148,7 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
 
   /// Overrides the default value for [WoltModalSheet] clipBehavior.
   ///
-  /// If null, [WoltModalSheet] uses [Clip.antiAliasWithSaveLayer].
+  /// Defaults to [Clip.antiAliasWithSaveLayer].
   @override
   Clip get clipBehavior => Clip.antiAliasWithSaveLayer;
 }

--- a/lib/src/theme/wolt_modal_sheet_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_theme_data.dart
@@ -147,7 +147,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
 
   /// Overrides the default value for [WoltModalSheet] clipBehavior.
   ///
-  /// If null, [WoltModalSheet] uses [Clip.antiAlias].
+  /// If null, [WoltModalSheet] uses [Clip.antiAliasWithSaveLayer].
   final Clip? clipBehavior;
 
   /// The default value for [WoltModalSheet] scrollPhysics in the main content.


### PR DESCRIPTION
## Description

This PR updates the default clip behavior of the WoltModalSheet from Clip.antiAlias to Clip.antiAliasWithSaveLayer. The change addresses a rendering issue where a thin border was visible at the top bar of the modal sheet, which was not the intended design.

## Changes
Modified the clipBehavior getter in WoltModalSheetThemeData to return Clip.antiAliasWithSaveLayer instead of Clip.antiAlias.

| antiAlias Vs antiAliasWithSaveLayer |
|--------|
| <img src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/9f12c073-63a1-44ac-b9a6-439147acef59"> |
| <img src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/62153fdd-9183-4cf3-bc45-9c8e7aaef784"> | 


## Related Issues
https://github.com/woltapp/wolt_modal_sheet/issues/162

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

