### PR TITLE
Bump minimum Flutter version to `3.10.6` and update Melos docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.2' # Uses the minimum supported version.
+          flutter-version: '3.10.6' # Uses the minimum supported version.
           channel: 'stable'
       # Setup Melos
       - name: Setup Melos
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.2' # Uses the minimum supported version.
+          flutter-version: '3.10.6' # Uses the minimum supported version.
           channel: 'stable'
       # Setup Melos
       - name: Setup Melos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,12 @@ To get started with contributing, please follow the steps below:
    ```
 5. Create a new branch from the `main` branch.
 6. Make your changes.
-7. Create a pull request.
+7. Run Melos format to format the code.
+   ```bash
+   melos format
+   ```
+8. Run Melos analyze to identify any issues.
+   ```bash
+   melos analyze
+   ```
+9. Create a pull request.

--- a/melos.yaml
+++ b/melos.yaml
@@ -18,9 +18,5 @@ command:
 scripts:
   analyze:
     exec: dart analyze .
-    # Uncomment to use with FVM :
-    # exec: fvm flutter analyze .
   format:
     exec: dart format --set-exit-if-changed .
-    # Uncomment to use with FVM :
-    # exec: fvm dart format --set-exit-if-changed .

--- a/playground/lib/home/pages/sheet_page_with_custom_top_bar.dart
+++ b/playground/lib/home/pages/sheet_page_with_custom_top_bar.dart
@@ -31,9 +31,9 @@ class SheetPageWithCustomTopBar {
       isTopBarLayerAlwaysVisible: false,
       topBar: _CustomTopBar(onClosed: onClosed, onBackPressed: onBackPressed),
       pageTitle: const ModalSheetTitle('Page with custom top bar'),
-      child: Column(
+      child: const Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: const [
+        children: [
           Padding(
             padding: EdgeInsets.all(16.0),
             child: Text(

--- a/playground/lib/home/pages/sheet_page_with_lazy_list.dart
+++ b/playground/lib/home/pages/sheet_page_with_lazy_list.dart
@@ -26,8 +26,8 @@ class SheetPageWithLazyList {
             ),
       topBarTitle: const ModalSheetTopBarTitle(titleText),
       heroImageHeight: heroImageHeight,
-      heroImage: Stack(
-        children: const [
+      heroImage: const Stack(
+        children: [
           ColoredBox(
             color: Colors.yellow,
             child: SizedBox(height: heroImageHeight, width: double.infinity),

--- a/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
+++ b/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
@@ -23,10 +23,10 @@ class SheetPageWithNoPageTitleNoTopBar {
         ),
       ),
       hasTopBarLayer: false,
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
+      child: const Padding(
+        padding: EdgeInsets.all(16.0),
         child: Column(
-          children: const [
+          children: [
             Text(
               '''
 This page has a very long scrollable content and does not have a page title and top bar.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.5.0
 repository: https://github.com/woltapp/wolt_modal_sheet
 
 environment:
-  sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.7.2'
+  sdk: '>=3.0.6 <4.0.0'
+  flutter: '>=3.10.6'
 
 dependencies:
   flutter:

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -176,8 +176,8 @@ void main() {
     const Size wideSize = Size(800.0, 600.0);
     const Size narrowSize = Size(300.0, 600.0);
 
-    tester.binding.window.physicalSizeTestValue = wideSize;
-    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    tester.view.physicalSize = wideSize;
+    tester.view.devicePixelRatio = 1.0;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -213,7 +213,7 @@ void main() {
     expect(tester.getTopLeft(sheetMaterial), const Offset(200.0, 253.0));
 
     // Configure to show the narrow layout.
-    tester.binding.window.physicalSizeTestValue = narrowSize;
+    tester.view.physicalSize = narrowSize;
     await tester.pumpAndSettle();
 
     // The default modalTypeBuilder should be a bottom sheet on narrow screens.
@@ -221,7 +221,7 @@ void main() {
     expect(tester.getTopLeft(sheetMaterial), const Offset(0.0, 510.0));
 
     // Reset the physical size and device pixel ratio.
-    tester.binding.window.clearPhysicalSizeTestValue();
-    tester.binding.window.clearDevicePixelRatioTestValue();
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
   });
 }


### PR DESCRIPTION
fixes [Bump minimum Flutter version required to `3.10.6`](https://github.com/woltapp/wolt_modal_sheet/issues/183)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

