### PR TITLE
Update PR deployment method

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -1,13 +1,17 @@
-name: Deploy to Firebase Hosting on PR
+name: Deploy Wolt Examples on PR
 'on': pull_request_target
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: subosito/flutter-action@v2.16.0
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml # path to pubspec.yaml
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./coffee_maker
       - run: flutter build web --release --web-renderer=canvaskit


### PR DESCRIPTION
## Description

Normally, when you generate PR deployment .yaml file from cli, it comes with on:pull_request. However, if there is a PR coming from the forked repos, github-action does not allow the incoming PR to reach the secrets and cannot receive firebase deployment information. For this reason, I changed pull_request to pull_request_target in the old PR and it could now access the secrets, but the problem this caused was now working in the codes on the deployment main. I missed this while making the last contribution. Currently, I checkout the incoming PR and then deploy. I tested it on my own repos and it works.
sample repository: https://github.com/AcarFurkan/workflow_trial

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

