### PR TITLE
Feature: add drag feature to Wolt Modal Bottom Sheet

### DIFF
--- a/lib/src/modal_page/non_scrolling_wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/non_scrolling_wolt_modal_sheet_page.dart
@@ -27,6 +27,7 @@ class NonScrollingWoltModalSheetPage extends SliverWoltModalSheetPage {
     required this.child,
     super.id,
     super.backgroundColor,
+    super.enableCloseDrag,
     super.enableDrag,
     super.leadingNavBarWidget,
     super.trailingNavBarWidget,

--- a/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
@@ -186,6 +186,10 @@ class SliverWoltModalSheetPage {
   /// `true`.
   final bool? hasSabGradient;
 
+  /// Controls the ability to close the bottom sheet by dragging. This setting overrides the value provided
+  /// via [WoltModalSheet.show] specifically for this page when the modal is displayed as a bottom sheet.
+  final bool? enableCloseDrag;
+
   /// Controls the draggability of the bottom sheet. This setting overrides the value provided
   /// via [WoltModalSheet.show] specifically for this page when the modal is displayed as a bottom sheet.
   final bool? enableDrag;
@@ -231,6 +235,7 @@ class SliverWoltModalSheetPage {
     this.backgroundColor,
     this.surfaceTintColor,
     this.hasSabGradient,
+    this.enableCloseDrag,
     this.enableDrag,
     this.sabGradientColor,
     this.forceMaxHeight = false,

--- a/lib/src/modal_page/wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/wolt_modal_sheet_page.dart
@@ -54,6 +54,7 @@ class WoltModalSheetPage extends SliverWoltModalSheetPage {
     super.surfaceTintColor,
     super.hasSabGradient,
     super.sabGradientColor,
+    super.enableCloseDrag,
     super.enableDrag,
     super.forceMaxHeight = false,
     super.resizeToAvoidBottomInset,
@@ -77,6 +78,7 @@ class WoltModalSheetPage extends SliverWoltModalSheetPage {
     Color? surfaceTintColor,
     bool? hasSabGradient,
     Color? sabGradientColor,
+    bool? enableCloseDrag,
     bool? enableDrag,
     bool? forceMaxHeight,
     bool? isTopBarLayerAlwaysVisible,
@@ -98,6 +100,7 @@ class WoltModalSheetPage extends SliverWoltModalSheetPage {
       surfaceTintColor: surfaceTintColor ?? this.surfaceTintColor,
       hasSabGradient: hasSabGradient ?? this.hasSabGradient,
       sabGradientColor: sabGradientColor ?? this.sabGradientColor,
+      enableCloseDrag: enableCloseDrag ?? this.enableCloseDrag,
       enableDrag: enableDrag ?? this.enableDrag,
       forceMaxHeight: forceMaxHeight ?? this.forceMaxHeight,
       isTopBarLayerAlwaysVisible:

--- a/lib/src/multi_child_layout/wolt_modal_multi_child_layout_delegate.dart
+++ b/lib/src/multi_child_layout/wolt_modal_multi_child_layout_delegate.dart
@@ -22,6 +22,12 @@ class WoltModalMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   /// The type of the scrollable modal.
   final WoltModalType modalType;
 
+  /// The animation controller for drag behavior.
+  final AnimationController? dragController;
+
+  /// Whether the modal content can be dragged.
+  final bool? enableDrag;
+
   /// Creates a [WoltModalMultiChildLayoutDelegate].
   ///
   /// [maxPageHeight] represents the maximum page height in the range of [0, 1] relative to the available size.
@@ -33,6 +39,14 @@ class WoltModalMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
   /// [barrierLayoutId] represents the layout identifier for the barrier.
   ///
   /// [modalType] represents the type of the scrollable modal.
+  ///
+  /// [minDialogWidth] represents the minimum width of the dialog.
+  ///
+  /// [maxDialogWidth] represents the maximum width of the dialog.
+  ///
+  /// [dragController] represents the animation controller for drag behavior.
+  ///
+  /// [enableDrag] represents whether the modal content can be dragged.
   WoltModalMultiChildLayoutDelegate({
     required this.maxPageHeight,
     required this.minPageHeight,
@@ -41,7 +55,10 @@ class WoltModalMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
     required this.modalType,
     required this.minDialogWidth,
     required this.maxDialogWidth,
-  });
+    this.dragController,
+    this.enableDrag,
+  }) : assert(enableDrag != true || dragController != null,
+            'If enableDrag is true, animationController must not be null.');
 
   @override
   void performLayout(Size size) {
@@ -54,15 +71,24 @@ class WoltModalMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
       barrierLayoutId,
       BoxConstraints(maxWidth: size.width, maxHeight: size.height),
     );
+    double maxHeight = enableDrag == true
+        ? (dragController!.value == 0.0
+            ? size.height * maxPageHeight
+            : dragController!.value * size.height)
+        : size.height * maxPageHeight;
+
     final modalHeight = layoutChild(
       contentLayoutId,
       BoxConstraints(
         minHeight: size.height * minPageHeight,
-        maxHeight: size.height * maxPageHeight,
+        maxHeight: maxHeight,
         maxWidth: modalWidth,
         minWidth: modalWidth,
       ),
     ).height;
+    if (enableDrag == true && dragController!.value == 0.0) {
+      dragController!.value = modalHeight / size.height;
+    }
 
     /// Position Modal Content
     positionChild(

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -68,7 +68,7 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
   /// Whether the bottom sheet can be dismissed by dragging.
   @override
   bool get enableCloseDrag => true;
-  
+
   /// Whether to enable the drag for bottom sheet.
   @override
   bool get enableDrag => false;

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -63,11 +63,15 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
 
   /// Whether to show the drag handle.
   @override
-  bool get showDragHandle => enableDrag;
+  bool get showDragHandle => enableCloseDrag || enableDrag;
 
+  /// Whether the bottom sheet can be dismissed by dragging.
+  @override
+  bool get enableCloseDrag => true;
+  
   /// Whether to enable the drag for bottom sheet.
   @override
-  bool get enableDrag => true;
+  bool get enableDrag => false;
 
   @override
   bool get resizeToAvoidBottomInset => true;

--- a/lib/src/theme/wolt_modal_sheet_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_theme_data.dart
@@ -15,6 +15,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     this.showDragHandle,
     this.dragHandleColor,
     this.dragHandleSize,
+    this.enableCloseDrag,
     this.enableDrag,
     this.topBarShadowColor,
     this.topBarElevation,
@@ -88,6 +89,9 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
 
   /// The size of the drag handle.
   final Size? dragHandleSize;
+
+  /// Controls the ability to close the bottom sheet by dragging.
+  final bool? enableCloseDrag;
 
   /// Whether the bottom sheet can be dragged.
   final bool? enableDrag;

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -653,8 +653,8 @@ class WoltModalSheetState extends State<WoltModalSheet>
     });
     if (widget.enableDrag ?? false) {
       _dragAnimationController = AnimationController(
-        duration:
-            const Duration(milliseconds: _defaultWoltModalDragAnimationDuration),
+        duration: const Duration(
+            milliseconds: _defaultWoltModalDragAnimationDuration),
         vsync: this,
       );
     }

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -18,6 +18,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     this.onModalDismissedWithDrag,
     this.modalBarrierColor,
     WoltModalTypeBuilder? modalTypeBuilder,
+    bool? enableCloseDrag,
     bool? enableDrag,
     bool? showDragHandle,
     bool? useSafeArea,
@@ -31,7 +32,8 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     double? maxDialogWidth,
     double? minPageHeight,
     double? maxPageHeight,
-  })  : _enableDrag = enableDrag,
+  })  : _enableCloseDrag = enableCloseDrag,
+        _enableDrag = enableDrag,
         _showDragHandle = showDragHandle,
         _useSafeArea = useSafeArea ?? true,
         _transitionAnimationController = transitionAnimationController,
@@ -62,6 +64,8 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
   final VoidCallback? onModalDismissedWithBarrierTap;
 
   final VoidCallback? onModalDismissedWithDrag;
+
+  final bool? _enableCloseDrag;
 
   final bool? _enableDrag;
 
@@ -126,6 +130,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
       onModalDismissedWithDrag: onModalDismissedWithDrag,
       animationController: animationController,
+      enableCloseDrag: _enableCloseDrag,
       enableDrag: _enableDrag,
       showDragHandle: _showDragHandle,
       useSafeArea: _useSafeArea,

--- a/playground/lib/home/dynamic_page_properties.dart
+++ b/playground/lib/home/dynamic_page_properties.dart
@@ -12,15 +12,15 @@ class DynamicPagePropertiesNotifier
 /// A model class that represents the dynamic properties of a page.
 class DynamicPagePropertiesModel {
   /// Indicates whether dragging is enabled for the bottom sheet.
-  final bool enableDrag;
+  final bool enableCloseDrag;
 
   /// Creates a [DynamicPagePropertiesModel] with the provided properties.
-  DynamicPagePropertiesModel({required this.enableDrag});
+  DynamicPagePropertiesModel({required this.enableCloseDrag});
 
   /// Creates a copy of [DynamicPagePropertiesModel] with optional property updates.
-  DynamicPagePropertiesModel copyWith({bool? enableDrag}) {
+  DynamicPagePropertiesModel copyWith({bool? enableCloseDrag}) {
     return DynamicPagePropertiesModel(
-      enableDrag: enableDrag ?? this.enableDrag,
+      enableCloseDrag: enableCloseDrag ?? this.enableCloseDrag,
     );
   }
 }

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -78,11 +78,12 @@ class _HomeScreenState extends State<HomeScreen> {
                     decorator: (child) {
                       return DynamicPageProperties(
                         notifier: DynamicPagePropertiesNotifier(
-                          DynamicPagePropertiesModel(enableDrag: true),
+                          DynamicPagePropertiesModel(enableCloseDrag: true),
                         ),
                         child: child,
                       );
                     },
+                    enableDrag: true,
                     maxDialogWidth: 560,
                     minDialogWidth: 400,
                     minPageHeight: 0.0,

--- a/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
+++ b/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
@@ -17,7 +17,8 @@ class SheetPageWithDynamicPageProperties {
     return WoltModalSheetPage(
       id: pageId,
       hasSabGradient: false,
-      enableDrag: DynamicPageProperties.of(context)?.value.enableDrag ?? false,
+      enableCloseDrag:
+          DynamicPageProperties.of(context)?.value.enableCloseDrag ?? false,
       stickyActionBar: Builder(builder: (context) {
         return Padding(
           padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
@@ -52,7 +53,7 @@ class SheetPageWithDynamicPageProperties {
                               DynamicPageProperties.of(context);
                           dynamicPageModel?.value =
                               dynamicPageModel.value.copyWith(
-                            enableDrag: newValue,
+                            enableCloseDrag: newValue,
                           );
                           setState(() =>
                               useOriginalPageValues = !useOriginalPageValues);


### PR DESCRIPTION
## Description

Scroll feature added to Wolt Modal Bottom sheet. `enableDrag` has been updated to `enableCloseDrag`. Now, when `enableDrag` is true, the position and size of the bottom sheet can change according to the user's wishes. `enableDrag` and `enableCloseDrag` can be used together or separately.
(I could not add these changes to the dynamic property page because there was a bug #205 in the operation of dynamic properties. That's why I assigned `enableDrag` to true in the home example so that you can test it.)



|  enableDrag=true && enableCloseDrag=false |  enableDrag=true && enableCloseDrag=true |
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/6f66e5bf-ca1e-4d6f-bce5-fc3aa3ff1f82"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/840c040f-4cbd-4d24-916c-9cc6bb5debf3"> | 


| enableDrag=false && enableCloseDrag=true | enableDrag=false && enableCloseDrag=false|
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/faf27915-3009-4826-93aa-37d77b195c78"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/65075121/f56a5d83-9b09-41df-951e-ea558cae342c"> | 

## Related Issues

fix #171 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

