### PR TITLE
Introduce updateCurrentPage method to update the currently visible page without pagination animation

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -585,6 +585,34 @@ class WoltModalSheet<T> extends StatefulWidget {
   static bool showPageWithId(BuildContext context, Object id) {
     return WoltModalSheet.of(context).showPageWithId(id);
   }
+
+  /// Updates the currently visible page in the modal sheet without pagination animation.
+  ///
+  /// This method directly modifies the properties of the current page, effectively
+  /// replacing it with the provided page instance. It's particularly useful for updating the
+  /// current page's non-widget content such as [SliverWoltModalSheetPage.enableDrag] or
+  /// [SliverWoltModalSheetPage.hasSabGradient].
+  ///
+  /// Usage Example:
+  /// ```dart
+  /// WoltModalSheet.of(context).updateCurrentPage(
+  ///   SliverWoltModalSheetPage(
+  ///     enableDrag: true,
+  ///     hasSabGradient: true,
+  ///     // additional properties
+  ///   )
+  /// );
+  /// ```
+  ///
+  /// Parameters:
+  ///   - `newPage`: The new configuration of the [SliverWoltModalSheetPage] to apply to the
+  ///   currently visible page.
+  static void updateCurrentPage(
+    BuildContext context,
+    SliverWoltModalSheetPage page,
+  ) {
+    WoltModalSheet.of(context).updateCurrentPage(page);
+  }
 }
 
 class WoltModalSheetState extends State<WoltModalSheet> {
@@ -1238,5 +1266,32 @@ class WoltModalSheetState extends State<WoltModalSheet> {
       return true;
     }
     return false;
+  }
+
+  /// Updates the currently visible page in the modal sheet without pagination animation.
+  ///
+  /// This method directly modifies the properties of the current page, effectively
+  /// replacing it with the provided page instance. It's particularly useful for updating the
+  /// current page's non-widget content such as [SliverWoltModalSheetPage.enableDrag] or
+  /// [SliverWoltModalSheetPage.hasSabGradient].
+  ///
+  /// Usage Example:
+  /// ```dart
+  /// WoltModalSheet.of(context).updateCurrentPage(
+  ///   SliverWoltModalSheetPage(
+  ///     enableDrag: true,
+  ///     hasSabGradient: true,
+  ///     // additional properties
+  ///   )
+  /// );
+  /// ```
+  ///
+  /// Parameters:
+  ///   - `newPage`: The new configuration of the [SliverWoltModalSheetPage] to apply to the
+  ///   currently visible page.
+  void updateCurrentPage(SliverWoltModalSheetPage newPage) {
+    setState(() {
+      _pages[_currentPageIndex] = newPage;
+    });
   }
 }

--- a/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
+++ b/playground/lib/home/pages/sheet_page_with_dynamic_page_properties.dart
@@ -11,8 +11,10 @@ class SheetPageWithDynamicPageProperties {
 
   static const ModalPageName pageId = ModalPageName.dynamicPageProperties;
 
-  static WoltModalSheetPage build(BuildContext context,
-      {bool isLastPage = true}) {
+  static WoltModalSheetPage build(
+    BuildContext context, {
+    bool isLastPage = true,
+  }) {
     bool useOriginalPageValues = true;
     return WoltModalSheetPage(
       id: pageId,
@@ -53,6 +55,10 @@ class SheetPageWithDynamicPageProperties {
                           dynamicPageModel?.value =
                               dynamicPageModel.value.copyWith(
                             enableDrag: newValue,
+                          );
+                          // Update the current page to reflect the changes.
+                          WoltModalSheet.of(context).updateCurrentPage(
+                            SheetPageWithDynamicPageProperties.build(context),
                           );
                           setState(() =>
                               useOriginalPageValues = !useOriginalPageValues);


### PR DESCRIPTION
## Description

This PR introduces the `updateCurrentPage` method to the WoltModalSheet widget, offering a way to update the currently visible modal sheet page without triggering pagination animations. Currently, the `WoltModalSheetPage` class is not widget, and this makes it difficult to update the non-widget configuration of the currently visible page. This method enables replacing the page completely with a new configuration.

## Related Issues

- Fixes https://github.com/woltapp/wolt_modal_sheet/issues/205

<video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/cbb4217b-6e1d-41c5-b117-4edae74d5301">

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

