### PR TITLE
Add coffee maker navigator 2 example to Firebase Deploy

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -13,6 +13,9 @@
         ],
         "playground_navigator2": [
           "playgroundnavigator2woltexample"
+        ],
+        "coffeemakernavigator2": [
+          "coffeemakernavigator2"
         ]
       }
     }

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -17,6 +17,8 @@ jobs:
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./coffee_maker
       - run: flutter build web --release --web-renderer=canvaskit
+        working-directory: ./coffee_maker_navigator_2
+      - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./playground
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./playground_navigator2

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,6 +15,8 @@ jobs:
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./coffee_maker
       - run: flutter build web --release --web-renderer=canvaskit
+        working-directory: ./coffee_maker_navigator_2
+      - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./playground
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./playground_navigator2

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ example/pubspec.lock
 coffee_maker/pubspec.lock
 playground/pubspec.lock
 playground_navigator2/pubspec.lock
+coffee_maker_navigator_2/pubspec.lock
 
 # pubspec_overrides
 pubspec_overrides.yaml
@@ -52,6 +53,7 @@ example/pubspec_overrides.yaml
 coffee_maker/pubspec_overrides.yaml
 playground/pubspec_overrides.yaml
 playground_navigator2/pubspec_overrides.yaml
+coffee_maker_navigator_2/pubspec_overrides.yaml
 
 # Symbolication related
 app.*.symbols

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ for page transitions, and scrollable content within each page.
   * [Coffee Maker Example](#coffee-maker-example)
   * [Playground Example](#playground-example)
   * [Playground Navigator2 Example](#playground-navigator2-example)
+  * [Coffee Maker Navigator2 Example](#coffee-maker-navigator2-example)
 - [Features](#features)
   * [Multi-Page Layout](#multi-page-layout)
   * [Scrollable Content](#scrollable-content)
@@ -86,6 +87,9 @@ You can review the usage examples of repository by clicking on the links.
 ### [Playground Example](https://playgroundwoltexample.web.app)
 
 ### [Playground Navigator2 Example](https://playgroundnavigator2woltexample.web.app)
+
+### [Coffee Maker Navigator2 Example](https://coffeemakernavigator2.web.app)
+
 
 ## Features
 

--- a/firebase.json
+++ b/firebase.json
@@ -44,6 +44,21 @@
         }
       ],
       "target": "playground_navigator2"
+    },
+    {
+      "public": "coffee_maker_navigator_2/build/web",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "target": "coffeemakernavigator2"
     }
   ]
 }


### PR DESCRIPTION
## Description

This PR introduces an example deploy of using the coffee maker navigator 2 in conjunction with Firebase Deploy. The existing behavior did not include an example deploy of how to integrate the coffee maker navigator 2.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

