### PR TITLE
Fix navigator_2_playground_example by Use static value notifier for button enabled listener

### DIFF
--- a/playground_navigator2/lib/modal/pages/root_sheet_page.dart
+++ b/playground_navigator2/lib/modal/pages/root_sheet_page.dart
@@ -8,12 +8,13 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 class RootSheetPage {
   RootSheetPage._();
 
+  static final ValueNotifier<bool> _isButtonEnabledNotifier = ValueNotifier(false);
+
   static WoltModalSheetPage build(BuildContext context) {
-    final ValueNotifier<bool> isButtonEnabledNotifier = ValueNotifier(false);
     const title = 'Choose a use case';
     return WoltModalSheetPage(
       stickyActionBar: ValueListenableBuilder<bool>(
-        valueListenable: isButtonEnabledNotifier,
+        valueListenable: _isButtonEnabledNotifier,
         builder: (_, value, __) {
           return Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
@@ -67,7 +68,7 @@ class RootSheetPage {
                 context
                     .read<RouterCubit>()
                     .onPathUpdated(selectedItemData.value);
-                isButtonEnabledNotifier.value = selectedItemData.isSelected;
+                _isButtonEnabledNotifier.value = selectedItemData.isSelected;
               },
             ),
             const _AllPagesPushWidget(),

--- a/playground_navigator2/lib/modal/pages/root_sheet_page.dart
+++ b/playground_navigator2/lib/modal/pages/root_sheet_page.dart
@@ -8,7 +8,8 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 class RootSheetPage {
   RootSheetPage._();
 
-  static final ValueNotifier<bool> _isButtonEnabledNotifier = ValueNotifier(false);
+  static final ValueNotifier<bool> _isButtonEnabledNotifier =
+      ValueNotifier(false);
 
   static WoltModalSheetPage build(BuildContext context) {
     const title = 'Choose a use case';


### PR DESCRIPTION
## Description

Every time the page was built on selection, the value notifier was reset to false. This PR fixes this issue by moving the enable notifier outside of the build method as static final field.

<video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/65ae2f03-98ab-4801-8071-6fcd21e29875">