### PR TITLE
Fix `WoltSelectionListTile` default padding and divider height in playground example

### DIFF
--- a/demo_ui_components/lib/src/selection_list/wolt_selection_list.dart
+++ b/demo_ui_components/lib/src/selection_list/wolt_selection_list.dart
@@ -150,7 +150,7 @@ class _WoltSelectionListState<T> extends State<WoltSelectionList<T>> {
                 },
               );
       },
-      separatorBuilder: (_, __) => const Divider(),
+      separatorBuilder: (_, __) => const Divider(height: 1.0),
       itemCount: _itemTileDataGroup.itemTileCount,
     );
   }

--- a/demo_ui_components/lib/src/selection_list/wolt_selection_list_tile.dart
+++ b/demo_ui_components/lib/src/selection_list/wolt_selection_list_tile.dart
@@ -69,8 +69,7 @@ class _WoltSelectionListTileState<T> extends State<WoltSelectionListTile<T>> {
       child: InkWell(
         onTap: _onTap,
         child: Padding(
-          padding:
-              widget.tilePadding ?? const EdgeInsets.symmetric(vertical: 16),
+          padding: widget.tilePadding ?? const EdgeInsets.all(16.0),
           child: Row(
             crossAxisAlignment:
                 widget.tileCrossAxisAlignment ?? CrossAxisAlignment.start,

--- a/playground/lib/home/pages/root_sheet_page.dart
+++ b/playground/lib/home/pages/root_sheet_page.dart
@@ -57,7 +57,7 @@ class RootSheetPage {
       trailingNavBarWidget: const WoltModalSheetCloseButton(),
       child: Builder(builder: (context) {
         return Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+          padding: const EdgeInsets.fromLTRB(0, 16, 0, 120),
           child: Column(
             children: [
               WoltSelectionList<ModalPageName?>.singleSelect(


### PR DESCRIPTION
fixes [`WoltSelectionListTile` has asymmetrical default padding](https://github.com/woltapp/wolt_modal_sheet/issues/220)

### Before



https://github.com/woltapp/wolt_modal_sheet/assets/48603081/3a5b70c5-bb45-40d3-88eb-5ff4c03f139e


### After




https://github.com/woltapp/wolt_modal_sheet/assets/48603081/b81b0413-e186-498f-8218-ea3a8132a8ef



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

