### PR TITLE
Improve safe area usage and color in modals

### DIFF
--- a/lib/src/modal_page/non_scrolling_wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/non_scrolling_wolt_modal_sheet_page.dart
@@ -35,6 +35,7 @@ class NonScrollingWoltModalSheetPage extends SliverWoltModalSheetPage {
     super.topBar,
     super.topBarTitle,
     super.navBarHeight,
+    super.useSafeArea,
   }) : super(
           isTopBarLayerAlwaysVisible: hasTopBarLayer,
           mainContentSliversBuilder: (_) => [

--- a/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
@@ -229,6 +229,10 @@ class SliverWoltModalSheetPage {
   /// The default value is set in [WoltModalSheetDefaultThemeData.resizeToAvoidBottomInset].
   final bool? resizeToAvoidBottomInset;
 
+  /// A boolean that determines whether the modal should avoid system UI intrusions such as the
+  /// notch and system gesture areas.
+  final bool? useSafeArea;
+
   /// Creates a page to be built within [WoltScrollableModalSheet].
   const SliverWoltModalSheetPage({
     this.mainContentSlivers,
@@ -253,6 +257,7 @@ class SliverWoltModalSheetPage {
     this.hasTopBarLayer,
     this.isTopBarLayerAlwaysVisible,
     this.resizeToAvoidBottomInset,
+    this.useSafeArea,
   })  : assert(!(topBar != null && hasTopBarLayer == false),
             "When topBar is provided, hasTopBarLayer must not be false"),
         assert(
@@ -308,6 +313,7 @@ class SliverWoltModalSheetPage {
       trailingNavBarWidget: trailingNavBarWidget ?? this.trailingNavBarWidget,
       resizeToAvoidBottomInset:
           resizeToAvoidBottomInset ?? this.resizeToAvoidBottomInset,
+      useSafeArea: useSafeArea ?? this.useSafeArea,
     );
   }
 
@@ -338,6 +344,7 @@ class SliverWoltModalSheetPage {
     Widget? leadingNavBarWidget,
     Widget? trailingNavBarWidget,
     bool? resizeToAvoidBottomInset,
+    bool? useSafeArea,
     Widget? child,
   }) {
     return SliverWoltModalSheetPage(
@@ -366,6 +373,7 @@ class SliverWoltModalSheetPage {
       trailingNavBarWidget: trailingNavBarWidget ?? this.trailingNavBarWidget,
       resizeToAvoidBottomInset:
           resizeToAvoidBottomInset ?? this.resizeToAvoidBottomInset,
+      useSafeArea: useSafeArea ?? this.useSafeArea,
     );
   }
 

--- a/lib/src/modal_page/wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/wolt_modal_sheet_page.dart
@@ -64,6 +64,7 @@ class WoltModalSheetPage extends SliverWoltModalSheetPage {
     super.leadingNavBarWidget,
     super.trailingNavBarWidget,
     super.topBar,
+    super.useSafeArea,
   }) : super(
           mainContentSliversBuilder: (context) => [
             SliverToBoxAdapter(child: child),

--- a/lib/src/modal_type/wolt_modal_type.dart
+++ b/lib/src/modal_type/wolt_modal_type.dart
@@ -4,12 +4,38 @@ import 'package:flutter/material.dart';
 
 /// Enum representing the type of the modal.
 enum WoltModalType {
-  bottomSheet,
-  dialog;
+  bottomSheet(
+    isTopSafeAreaFilled: false,
+    isBottomSafeAreaFilled: true,
+    isStartSafeAreaFilled: false,
+    isEndSafeAreaFilled: false,
+  ),
+  dialog(
+    isTopSafeAreaFilled: false,
+    isBottomSafeAreaFilled: true,
+    isStartSafeAreaFilled: false,
+    isEndSafeAreaFilled: false,
+  );
 
-  const WoltModalType();
+  const WoltModalType({
+    required this.isBottomSafeAreaFilled,
+    required this.isTopSafeAreaFilled,
+    required this.isStartSafeAreaFilled,
+    required this.isEndSafeAreaFilled,
+  });
 
-  /// Returns the width of the modal content based on the total [totalWidth].
+  final bool isBottomSafeAreaFilled;
+  final bool isTopSafeAreaFilled;
+  final bool isStartSafeAreaFilled;
+  final bool isEndSafeAreaFilled;
+
+  /// Provides a semantic label for accessibility purposes based on the modal type.
+  ///
+  /// Accessibility labels help screen readers describe the function of the modal to users with
+  /// visual impairments.
+  ///
+  /// Parameters:
+  /// - [context]: The build context used to access MaterialLocalizations.
   ///
   /// The [totalWidth] represents the total available width for the modal.
   double modalContentWidth(

--- a/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_default_theme_data.dart
@@ -154,6 +154,11 @@ class WoltModalSheetDefaultThemeData extends WoltModalSheetThemeData {
   @override
   Clip get clipBehavior => Clip.antiAliasWithSaveLayer;
 
+  /// A boolean that determines whether the modal should avoid system UI intrusions such as the
+  /// notch and system gesture areas.
+  @override
+  bool get useSafeArea => true;
+
   /// Motion animation styles for both pagination and page scrolling.
   @override
   WoltModalSheetAnimationStyle get animationStyle =>

--- a/lib/src/theme/wolt_modal_sheet_theme_data.dart
+++ b/lib/src/theme/wolt_modal_sheet_theme_data.dart
@@ -35,6 +35,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     this.mainContentScrollPhysics,
     this.animationStyle,
     this.resizeToAvoidBottomInset,
+    this.useSafeArea,
   });
 
   /// The color of the surface tint overlay applied to the material color
@@ -169,6 +170,10 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
   /// Defaults to true.
   final bool? resizeToAvoidBottomInset;
 
+  /// A boolean that determines whether the modal should avoid system UI intrusions such as the
+  /// notch and system gesture areas.
+  final bool? useSafeArea;
+
   @override
   WoltModalSheetThemeData copyWith({
     Color? backgroundColor,
@@ -197,6 +202,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
     ScrollPhysics? mainContentScrollPhysics,
     WoltModalSheetAnimationStyle? animationStyle,
     bool? resizeToAvoidBottomInset,
+    bool? useSafeArea,
   }) {
     return WoltModalSheetThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -228,6 +234,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
       animationStyle: animationStyle ?? this.animationStyle,
       resizeToAvoidBottomInset:
           resizeToAvoidBottomInset ?? this.resizeToAvoidBottomInset,
+      useSafeArea: useSafeArea ?? this.useSafeArea,
     );
   }
 
@@ -270,6 +277,7 @@ class WoltModalSheetThemeData extends ThemeExtension<WoltModalSheetThemeData> {
       mainContentScrollPhysics:
           t < 0.5 ? mainContentScrollPhysics : other.mainContentScrollPhysics,
       animationStyle: t < 0.5 ? animationStyle : other.animationStyle,
+      useSafeArea: t < 0.5 ? useSafeArea : other.useSafeArea,
     );
   }
 }

--- a/lib/src/widgets/wolt_modal_safe_area_filling.dart
+++ b/lib/src/widgets/wolt_modal_safe_area_filling.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/src/modal_type/wolt_modal_type.dart';
+
+/// A widget that fills the safe areas around a modal with a specified color based on the modal's type.
+///
+/// This widget is designed to be used in scenarios where the modal needs to adapt to different
+/// safe area constraints, such as on different devices or orientations. It takes into consideration
+/// the modal's type to decide which safe areas (top, bottom, start, end) need to be filled.
+/// ```
+class WoltModalSafeAreaFilling extends StatelessWidget {
+  /// Defines the type of modal, which affects how safe areas are filled.
+  final WoltModalType modalType;
+
+  /// The color used to fill the safe areas.
+  final Color safeAreaColor;
+
+  /// The main content of the modal.
+  final Widget child;
+
+  const WoltModalSafeAreaFilling({
+    super.key,
+    required this.modalType,
+    required this.safeAreaColor,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        if (modalType.isStartSafeAreaFilled)
+          _StartSafeAreaFilling(safeAreaColor),
+        Expanded(
+          child: Column(
+            children: [
+              if (modalType.isTopSafeAreaFilled)
+                _TopSafeAreaFilling(safeAreaColor),
+              Expanded(child: child),
+              if (modalType.isBottomSafeAreaFilled)
+                _BottomSafeAreaFilling(safeAreaColor),
+            ],
+          ),
+        ),
+        if (modalType.isEndSafeAreaFilled) _EndSafeAreaFilling(safeAreaColor),
+      ],
+    );
+  }
+}
+
+class _TopSafeAreaFilling extends StatelessWidget {
+  final Color safeAreaColor;
+
+  const _TopSafeAreaFilling(this.safeAreaColor);
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: safeAreaColor,
+      child: SizedBox(
+        height: MediaQuery.of(context).padding.top,
+        width: double.infinity,
+      ),
+    );
+  }
+}
+
+class _BottomSafeAreaFilling extends StatelessWidget {
+  final Color safeAreaColor;
+
+  const _BottomSafeAreaFilling(this.safeAreaColor);
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: safeAreaColor,
+      child: SizedBox(
+        height: MediaQuery.of(context).padding.bottom,
+        width: double.infinity,
+      ),
+    );
+  }
+}
+
+class _StartSafeAreaFilling extends StatelessWidget {
+  final Color safeAreaColor;
+
+  const _StartSafeAreaFilling(this.safeAreaColor);
+
+  @override
+  Widget build(BuildContext context) {
+    final TextDirection textDirection = Directionality.of(context);
+    final EdgeInsets padding = MediaQuery.of(context).padding;
+    switch (textDirection) {
+      case TextDirection.ltr:
+        return ColoredBox(
+          color: safeAreaColor,
+          child: SizedBox(
+            height: double.infinity,
+            width: padding.left,
+          ),
+        );
+      case TextDirection.rtl:
+        return ColoredBox(
+          color: safeAreaColor,
+          child: SizedBox(
+            height: double.infinity,
+            width: padding.right,
+          ),
+        );
+    }
+  }
+}
+
+class _EndSafeAreaFilling extends StatelessWidget {
+  final Color safeAreaColor;
+
+  const _EndSafeAreaFilling(this.safeAreaColor);
+
+  @override
+  Widget build(BuildContext context) {
+    final TextDirection textDirection = Directionality.of(context);
+    final EdgeInsets padding = MediaQuery.of(context).padding;
+    switch (textDirection) {
+      case TextDirection.ltr:
+        return ColoredBox(
+          color: safeAreaColor,
+          child: SizedBox(
+            height: double.infinity,
+            width: padding.right,
+          ),
+        );
+      case TextDirection.rtl:
+        return ColoredBox(
+          color: safeAreaColor,
+          child: SizedBox(
+            height: double.infinity,
+            width: padding.left,
+          ),
+        );
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is a small PR necessary for introducing the Side Sheet and custom modal sheet types. The primary focus of this PR is to improve the handling of safe areas based on modal types.

### Dynamic Safe Area Adjustment:

Earlier, the configuration of enable or disable safe area adjustments was based on the modal level so that it was only possible to set the `useSafeArea` for all pages in modal when calling the `show` method. This PR enables this configuration in theme level and page level. This is necessary for example when a side sheet page has an image on top and the top safe area should be excluded. Example:

<img width="1288" alt="image" src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/037a68b0-684c-4944-b558-c7295ddba3a5">

### Enhanced Safe Area Filling:

Implemented new widgets (_TopSafeAreaFilling, _BottomSafeAreaFilling, _StartSafeAreaFilling, _EndSafeAreaFilling) to fill safe areas with the correct page background color. Earlier, we were using the page background color without consideration of the elevation and surface tint color.

See the pink color difference before after between the safe area and the page backgroound color.

| Before | After |
|--------|--------|
| ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/2b973fa9-4721-4acb-a716-deab9c7dbbd0) | ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/bf9afe2e-68f7-4ec3-b5e0-0cea4d009bb6) | 

#### Use Safe Area : True
| Side Sheet Bottom & Top Safe Area | Side Sheet End Safe Area |
|--------|--------|
| ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/375e7a73-525e-42a7-9b2a-46fb515a1776) | ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/08825aa9-27c3-44e5-9f61-d8d6a03569e7) | 

#### Use Safe Area : False

| Side Sheet Portrait | Side Sheet Landscape |
|--------|--------|
| ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/97f490ce-cc14-49db-bdf8-82a036232cec) | ![image](https://github.com/woltapp/wolt_modal_sheet/assets/13782003/d87c7c5b-f59f-438a-9281-e94883c3ed94) | 


## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/woltapp/wolt_modal_sheet/issues). Indicate, which of these issues are resolved or fixed by this PR.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

