### PR TITLE
Dispose value notifier in WoltModalSheet

### DIFF
--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -536,7 +536,7 @@ class WoltModalSheetState extends State<WoltModalSheet> {
       setState(() {
         final pages = widget.pageListBuilderNotifier.value(context);
         assert(
-        pages.isNotEmpty, 'pageListBuilder must return a non-empty list.');
+            pages.isNotEmpty, 'pageListBuilder must return a non-empty list.');
         _pages
           ..clear()
           ..addAll(pages);

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -352,18 +352,15 @@ class WoltModalSheetState extends State<WoltModalSheet> {
   @override
   void initState() {
     super.initState();
-    widget.pageListBuilderNotifier.addListener(() {
-      // Update the page list whenever the notifier changes. This is useful when the page list is
-      // set in a declarative way using the WoltModalSheetRoute.
-      setState(() {
-        final pages = widget.pageListBuilderNotifier.value(context);
-        assert(
-            pages.isNotEmpty, 'pageListBuilder must return a non-empty list.');
-        _pages
-          ..clear()
-          ..addAll(pages);
-      });
-    });
+    widget.pageListBuilderNotifier
+        .addListener(_onPageListBuilderNotifierValueUpdated);
+  }
+
+  @override
+  void dispose() {
+    widget.pageListBuilderNotifier
+        .removeListener(_onPageListBuilderNotifierValueUpdated);
+    super.dispose();
   }
 
   @override
@@ -532,6 +529,19 @@ class WoltModalSheetState extends State<WoltModalSheet> {
         );
       },
     );
+  }
+
+  void _onPageListBuilderNotifierValueUpdated() {
+    if (context.mounted) {
+      setState(() {
+        final pages = widget.pageListBuilderNotifier.value(context);
+        assert(
+        pages.isNotEmpty, 'pageListBuilder must return a non-empty list.');
+        _pages
+          ..clear()
+          ..addAll(pages);
+      });
+    }
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -65,6 +65,90 @@ void main() {
     });
   });
 
+  group('WoltModalSheet State Management', () {
+    testWidgets('should update pages when notifier changes',
+        (WidgetTester tester) async {
+      final pageListBuilderNotifier = ValueNotifier((BuildContext _) => [
+            WoltModalSheetPage(
+              child: const Text('Initial Page'),
+            ),
+          ]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WoltModalSheet(
+            pageListBuilderNotifier: pageListBuilderNotifier,
+            pageIndexNotifier: ValueNotifier(0),
+            onModalDismissedWithBarrierTap: () {},
+            onModalDismissedWithDrag: () {},
+            decorator: null,
+            modalTypeBuilder: (_) => WoltModalType.bottomSheet,
+            animationController: null,
+            route: WoltModalSheetRoute<void>(
+                pageListBuilderNotifier: pageListBuilderNotifier),
+            enableDrag: null,
+            showDragHandle: null,
+            useSafeArea: false,
+          ),
+        ),
+      );
+
+      // Initial state check
+      expect(find.text('Initial Page'), findsOneWidget);
+
+      // Update the notifier
+      pageListBuilderNotifier.value = (_) => [
+            WoltModalSheetPage(child: const Text('Updated Page')),
+          ];
+
+      // Trigger the listener
+      pageListBuilderNotifier.notifyListeners();
+      await tester.pumpAndSettle();
+
+      // Check if the UI is updated
+      expect(find.text('Updated Page'), findsOneWidget);
+    });
+
+    testWidgets('listener should be removed on dispose',
+        (WidgetTester tester) async {
+      final pageListBuilderNotifier = ValueNotifier((_) => [
+            WoltModalSheetPage(child: const Text('Initial Page')),
+          ]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WoltModalSheet(
+            pageListBuilderNotifier: pageListBuilderNotifier,
+            pageIndexNotifier: ValueNotifier(0),
+            onModalDismissedWithBarrierTap: () {},
+            onModalDismissedWithDrag: () {},
+            decorator: null,
+            modalTypeBuilder: (_) => WoltModalType.bottomSheet,
+            animationController: null,
+            route: WoltModalSheetRoute<void>(
+                pageListBuilderNotifier: pageListBuilderNotifier),
+            enableDrag: null,
+            showDragHandle: null,
+            useSafeArea: false,
+          ),
+        ),
+      );
+
+      // Update the notifier after the widget is disposed
+      await tester.pumpWidget(Container()); // Dispose the widget
+      pageListBuilderNotifier.value = (_) => [
+            WoltModalSheetPage(child: const Text('Should Not Update')),
+          ];
+
+      // Trigger the listener
+      pageListBuilderNotifier.notifyListeners();
+      await tester.pumpAndSettle();
+
+      // Since the widget is disposed, this text should not be found
+      expect(find.text('Should Not Update'), findsNothing);
+    });
+  });
+
   group('barrierDismissible', () {
     testWidgets(
         'Does not dismiss on barrier tap if barrierDismissible is false',


### PR DESCRIPTION
## Description

The `pageListBuilderNotifier` listener should have been disposed properly when the widget is demounted. This causes issues when you launch the modal sheet in the second time. This error is easily reproducible thanks to the well documented issue https://github.com/woltapp/wolt_modal_sheet/issues/226

| Before | After |
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/c6b86418-80bb-469f-9d7b-adc208f0e8c7"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/e3381318-9fb3-4983-b95a-dc7e46ac46b8"> | 


## Related Issues

https://github.com/woltapp/wolt_modal_sheet/issues/226

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

