### PR TITLE
Add `WoltModalSheetPageSafeArea` to control safe area on the page level

### DIFF
--- a/lib/src/modal_page/wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/wolt_modal_sheet_page.dart
@@ -70,3 +70,50 @@ class WoltModalSheetPage extends SliverWoltModalSheetPage {
           ],
         );
 }
+
+class WoltModalSheetPageSafeArea extends SliverWoltModalSheetPage {
+  /// Whether to avoid system intrusions on the left.
+  final bool left;
+
+  /// Whether to avoid system intrusions at the top of the screen, typically the
+  /// system status bar.
+  final bool top;
+
+  /// Whether to avoid system intrusions on the right.
+  final bool right;
+
+  /// Whether to avoid system intrusions on the bottom side of the screen.
+  final bool bottom;
+
+  WoltModalSheetPageSafeArea({
+    this.left = true,
+    this.top = true,
+    this.right = true,
+    this.bottom = true,
+    required WoltModalSheetPage page,
+  }) : super(
+          id: page.id,
+          pageTitle: page.pageTitle,
+          navBarHeight: page.navBarHeight,
+          topBarTitle: page.topBarTitle,
+          heroImage: page.heroImage,
+          heroImageHeight: page.heroImageHeight,
+          backgroundColor: page.backgroundColor,
+          surfaceTintColor: page.surfaceTintColor,
+          hasSabGradient: page.hasSabGradient,
+          sabGradientColor: page.sabGradientColor,
+          enableDrag: page.enableDrag,
+          forceMaxHeight: page.forceMaxHeight,
+          resizeToAvoidBottomInset: page.resizeToAvoidBottomInset,
+          isTopBarLayerAlwaysVisible: page.isTopBarLayerAlwaysVisible,
+          hasTopBarLayer: page.hasTopBarLayer,
+          scrollController: page.scrollController,
+          stickyActionBar: page.stickyActionBar,
+          leadingNavBarWidget: page.leadingNavBarWidget,
+          trailingNavBarWidget: page.trailingNavBarWidget,
+          topBar: page.topBar,
+          mainContentSliversBuilder: (context) => [
+            SliverToBoxAdapter(child: page.child),
+          ],
+        );
+}

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -486,13 +486,44 @@ class WoltModalSheetState extends State<WoltModalSheet> {
                         clipBehavior: clipBehavior,
                         child: LayoutBuilder(
                           builder: (_, constraints) {
-                            return WoltModalSheetAnimatedSwitcher(
+                            final Widget switcherWudget =
+                                WoltModalSheetAnimatedSwitcher(
                               woltModalType: _modalType,
                               pageIndex: currentPageIndex,
                               pages: pages,
                               sheetWidth: constraints.maxWidth,
                               showDragHandle: showDragHandle,
                             );
+
+                            if (page is WoltModalSheetPageSafeArea) {
+                              return Stack(
+                                children: [
+                                  SafeArea(
+                                    top: page.top,
+                                    bottom: page.bottom,
+                                    left: page.left,
+                                    right: page.right,
+                                    child: switcherWudget,
+                                  ),
+                                  if (_modalType == WoltModalType.bottomSheet)
+                                    Positioned(
+                                      bottom: 0,
+                                      left: 0,
+                                      right: 0,
+                                      child: ColoredBox(
+                                        color: pageBackgroundColor,
+                                        child: SizedBox(
+                                          height: MediaQuery.paddingOf(context)
+                                              .bottom,
+                                          width: double.infinity,
+                                        ),
+                                      ),
+                                    ),
+                                ],
+                              );
+                            }
+
+                            return switcherWudget;
                           },
                         ),
                       ),

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -486,7 +486,7 @@ class WoltModalSheetState extends State<WoltModalSheet> {
                         clipBehavior: clipBehavior,
                         child: LayoutBuilder(
                           builder: (_, constraints) {
-                            final Widget switcherWudget =
+                            final Widget switcherWidget =
                                 WoltModalSheetAnimatedSwitcher(
                               woltModalType: _modalType,
                               pageIndex: currentPageIndex,
@@ -503,7 +503,7 @@ class WoltModalSheetState extends State<WoltModalSheet> {
                                     bottom: page.bottom,
                                     left: page.left,
                                     right: page.right,
-                                    child: switcherWudget,
+                                    child: switcherWidget,
                                   ),
                                   if (_modalType == WoltModalType.bottomSheet)
                                     Positioned(

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -523,7 +523,7 @@ class WoltModalSheetState extends State<WoltModalSheet> {
                               );
                             }
 
-                            return switcherWudget;
+                            return switcherWidget;
                           },
                         ),
                       ),


### PR DESCRIPTION
### Proposal 

This introduces `WoltModalSheetPageSafeArea` to provide safe area control on the page level. Please see the demo below. 

This should work for modal type:
- Bottom sheet (See the demo below)
- Side sheet (when introduced)
- Dialog (I'm not sure if the page level safe area control is feasible for the dialog as the dialog needs to recreated to adjust the dialog size for the safe area. It would mean dialog has to be closed and opened again. I may need more info on this idea)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';
import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(useMaterial3: true),
      home: Scaffold(
        body: Center(
          child: Builder(builder: (context) {
            return ElevatedButton(
              onPressed: () {
                WoltModalSheet.show<void>(
                  context: context,
                  pageListBuilder: (modalSheetContext) {
                    final Widget stickyActionBar = Row(
                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                      children: [
                        FilledButton(
                          onPressed: Navigator.of(modalSheetContext).pop,
                          child: const Text('Close'),
                        ),
                        ElevatedButton(
                          onPressed:
                              WoltModalSheet.of(modalSheetContext).showNext,
                          child: const Text('Next'),
                        ),
                      ],
                    );
                    final List<SliverWoltModalSheetPage> pages =
                        <SliverWoltModalSheetPage>[
                      WoltModalSheetPageSafeArea(
                        page: WoltModalSheetPage(
                          stickyActionBar: stickyActionBar,
                          child: Column(
                            children: <Widget>[
                              Image.network('https://i.imgur.com/3uuQ0Y0.jpeg'),
                              const Placeholder(fallbackHeight: 1000),
                            ],
                          ),
                        ),
                      ),
                      WoltModalSheetPage(
                        stickyActionBar: stickyActionBar,
                        child: Column(
                          children: <Widget>[
                            Padding(
                              padding: const EdgeInsets.all(16.0),
                              child: Text(
                                'Page 2',
                                style:
                                    Theme.of(context).textTheme.headlineLarge,
                              ),
                            ),
                            const Placeholder(fallbackHeight: 1000),
                          ],
                        ),
                      ),
                      WoltModalSheetPageSafeArea(
                          page: WoltModalSheetPage(
                        stickyActionBar: stickyActionBar,
                        child: const Column(
                          children: <Widget>[
                            FlutterLogo(size: 400),
                            Placeholder(fallbackHeight: 1000),
                          ],
                        ),
                      )),
                    ];

                    return pages
                        .map((SliverWoltModalSheetPage page) => page)
                        .toList();
                  },
                  onModalDismissedWithBarrierTap: () =>
                      Navigator.of(context).pop(),
                  modalTypeBuilder: (context) => WoltModalType.bottomSheet,
                  useSafeArea:
                      false, // Turn off main content safe area to use `WoltModalSheetPageSafeArea` instead.
                );
              },
              child: const Text('Show Sheet'),
            );
          }),
        ),
      ),
    );
  }
}
```

</details>


https://github.com/woltapp/wolt_modal_sheet/assets/48603081/e2ffb7d8-feda-463f-8459-75a060904001



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

