### PR TITLE
Add custom modal type examples to the playground app

### DIFF
--- a/coffee_maker/lib/home/online/modal_pages/add_water/add_water_description_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/add_water/add_water_description_modal_page.dart
@@ -47,7 +47,8 @@ class AddWaterDescriptionModalPage {
         return WoltModalSheetCloseButton(onClosed: Navigator.of(context).pop);
       }),
       child: const Padding(
-        padding: EdgeInsets.only(bottom: (2 * WoltElevatedButton.height) + 8),
+        padding:
+            EdgeInsets.only(bottom: (2 * WoltElevatedButton.defaultHeight) + 8),
         child: Padding(
           padding: EdgeInsets.all(16.0),
           child: ModalSheetContentText(

--- a/coffee_maker/lib/home/online/modal_pages/grind/grind_or_reject_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/grind/grind_or_reject_modal_page.dart
@@ -43,7 +43,8 @@ class GrindOrRejectModalPage {
       ),
       trailingNavBarWidget: const WoltModalSheetCloseButton(),
       child: const Padding(
-        padding: EdgeInsets.only(bottom: (2 * WoltElevatedButton.height) + 48),
+        padding: EdgeInsets.only(
+            bottom: (2 * WoltElevatedButton.defaultHeight) + 48),
         child: Padding(
           padding: EdgeInsets.all(16.0),
           child:

--- a/coffee_maker/lib/home/online/modal_pages/ready/offer_recommendation_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/ready/offer_recommendation_modal_page.dart
@@ -66,7 +66,9 @@ class OfferRecommendationModalPage {
                     16,
                     16,
                     16,
-                    index == tileCount - 1 ? WoltElevatedButton.height * 2 : 0,
+                    index == tileCount - 1
+                        ? WoltElevatedButton.defaultHeight * 2
+                        : 0,
                   ),
                   child: ExtraRecommendationTile(
                     recommendation: recommendation,

--- a/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/grind/grind_or_reject_modal_page.dart
+++ b/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/grind/grind_or_reject_modal_page.dart
@@ -12,8 +12,8 @@ class GrindOrRejectModalPage extends WoltModalSheetPage {
         onCoffeeOrderStatusChange,
   ) : super(
           child: const Padding(
-            padding:
-                EdgeInsets.only(bottom: (2 * WoltElevatedButton.height) + 48),
+            padding: EdgeInsets.only(
+                bottom: (2 * WoltElevatedButton.defaultHeight) + 48),
             child: Padding(
               padding: EdgeInsets.all(16.0),
               child: ModalSheetContentText(

--- a/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/ready/offer_recommendation_modal_page.dart
+++ b/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/ready/offer_recommendation_modal_page.dart
@@ -66,7 +66,9 @@ class OfferRecommendationModalPage {
                     16,
                     16,
                     16,
-                    index == tileCount - 1 ? WoltElevatedButton.height * 2 : 0,
+                    index == tileCount - 1
+                        ? WoltElevatedButton.defaultHeight * 2
+                        : 0,
                   ),
                   child: ExtraRecommendationTile(
                     recommendation: recommendation,

--- a/demo_ui_components/lib/src/button/wolt_elevated_button.dart
+++ b/demo_ui_components/lib/src/button/wolt_elevated_button.dart
@@ -9,17 +9,19 @@ class WoltElevatedButton extends StatelessWidget {
     this.enabled = true,
     this.colorName = WoltColorName.blue,
     this.theme = WoltElevatedButtonTheme.primary,
+    this.height = defaultHeight,
     required this.onPressed,
     required this.child,
   });
 
-  static const height = 56.0;
+  static const defaultHeight = 56.0;
 
   final WoltColorName colorName;
   final WoltElevatedButtonTheme theme;
   final bool enabled;
   final VoidCallback onPressed;
   final Widget child;
+  final double height;
 
   @override
   Widget build(BuildContext context) {

--- a/demo_ui_components/lib/src/colors/wolt_colors.dart
+++ b/demo_ui_components/lib/src/colors/wolt_colors.dart
@@ -20,6 +20,9 @@ class WoltColors {
   static const red16 = Color(0xFFFEDFDC);
   static const red8 = Color(0xFFFFEFEE);
 
+  static const yellow = Color(0xFFFEA90D);
+  static const yellow8 = Color(0xFFFFF9EC);
+
   static const blue = Color(0xFF009DE0);
   static const blue64 = Color(0xFF5CC0EB);
   static const blue48 = Color(0xFF99D8F3);

--- a/lib/src/modal_type/wolt_modal_type.dart
+++ b/lib/src/modal_type/wolt_modal_type.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:wolt_modal_sheet/src/modal_type/wolt_modal_dismiss_direction.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 export 'wolt_bottom_sheet_type.dart';
@@ -23,6 +22,7 @@ abstract class WoltModalType {
     this.transitionDuration = const Duration(milliseconds: 300),
     this.reverseTransitionDuration = const Duration(milliseconds: 300),
     this.minFlingVelocity = 700.0,
+    this.closeProgressThreshold = 0.5,
   });
 
   /// Creates the default bottom sheet modal.
@@ -75,6 +75,13 @@ abstract class WoltModalType {
   ///
   /// This is useful for modals like side sheets that need to occupy the full screen height.
   final bool forceMaxHeight;
+
+  /// Threshold value for determining when the modal should close during a drag gesture.
+  /// If the animation's progress value falls below this threshold during a drag,
+  /// the modal will be dismissed. The value should be between 0.0 and 1.0, where:
+  /// - A higher value (closer to 1.0) means the modal will be easier to dismiss.
+  /// - A lower value (closer to 0.0) means the modal will be harder to dismiss
+  final double closeProgressThreshold;
 
   /// Defines the constraints for the modal based on the available screen size.
   ///

--- a/lib/src/widgets/wolt_modal_sheet_content_gesture_detector.dart
+++ b/lib/src/widgets/wolt_modal_sheet_content_gesture_detector.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:wolt_modal_sheet/src/modal_type/wolt_modal_dismiss_direction.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
-
-const double _closeProgressThreshold = 0.5;
 
 class WoltModalSheetContentGestureDetector extends StatelessWidget {
   const WoltModalSheetContentGestureDetector({
@@ -112,7 +109,7 @@ class WoltModalSheetContentGestureDetector extends StatelessWidget {
       }
     }
 
-    if (_animationController.value < _closeProgressThreshold) {
+    if (_animationController.value < modalType.closeProgressThreshold) {
       if (_animationController.value > 0.0) {
         _animationController.fling(velocity: -1.0);
       }
@@ -201,7 +198,7 @@ class WoltModalSheetContentGestureDetector extends StatelessWidget {
           }
         }
       }
-    } else if (_animationController.value < 0.5) {
+    } else if (_animationController.value < modalType.closeProgressThreshold) {
       _animationController.fling(velocity: -1.0);
       isClosing = true;
     } else {

--- a/lib/wolt_modal_sheet.dart
+++ b/lib/wolt_modal_sheet.dart
@@ -4,6 +4,7 @@ export 'src/modal_page/sliver_wolt_modal_sheet_page.dart';
 export 'src/modal_page/wolt_modal_sheet_page.dart';
 export 'src/modal_page/non_scrolling_wolt_modal_sheet_page.dart';
 export 'src/modal_type/wolt_modal_type.dart';
+export 'src/modal_type/wolt_modal_dismiss_direction.dart';
 export 'src/theme/wolt_modal_sheet_theme_data.dart';
 export 'src/wolt_modal_sheet.dart';
 export 'src/wolt_modal_sheet_route.dart';

--- a/playground/android/app/build.gradle
+++ b/playground/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.wolt_modal_sheet.playground.playground"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 19
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/playground/lib/home/custom_sheets/floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/floating_bottom_sheet_type.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class FloatingBottomSheetType extends WoltModalType {
+  final EdgeInsetsDirectional padding;
+  static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
+  static const Duration _defaultExitDuration = Duration(milliseconds: 300);
+
+  const FloatingBottomSheetType({
+    this.padding = const EdgeInsetsDirectional.all(16.0),
+  }) : super(
+          shapeBorder: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(28.0)),
+          ),
+          showDragHandle: false,
+          dismissDirection: WoltModalDismissDirection.down,
+          transitionDuration: _defaultEnterDuration,
+          reverseTransitionDuration: _defaultExitDuration,
+        );
+
+  @override
+  String routeLabel(BuildContext context) {
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
+    return localizations.bottomSheetLabel;
+  }
+
+  @override
+  BoxConstraints layoutModal(Size availableSize) {
+    const padding = 32.0;
+    final availableWidth = availableSize.width;
+    double width = availableWidth > 523.0 ? 312.0 : availableWidth - padding;
+
+    if (availableWidth > 523.0) {
+      width = 312.0;
+    } else if (availableWidth > 240.0) {
+      width = 240.0;
+    } else {
+      width = availableWidth * 0.7;
+    }
+
+    return BoxConstraints(
+      minWidth: width,
+      maxWidth: width,
+      minHeight: 0,
+      maxHeight: availableSize.height * 0.8,
+    );
+  }
+
+  @override
+  Offset positionModal(
+      Size availableSize, Size modalContentSize, TextDirection textDirection) {
+    return Offset(
+      availableSize.width - modalContentSize.width - padding.end,
+      availableSize.height - modalContentSize.height - padding.bottom,
+    );
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final alphaAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: const Interval(0.0, 100.0 / 300.0, curve: Curves.linear),
+      reverseCurve: const Interval(100.0 / 250.0, 1.0, curve: Curves.linear),
+    ));
+
+    final slideAnimation = Tween<Offset>(
+      begin: const Offset(1, 1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeInOutCubic,
+    ));
+
+    final scaleAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeInOutCubic,
+    ));
+
+    return FadeTransition(
+      opacity: alphaAnimation,
+      child: SlideTransition(
+        position: slideAnimation,
+        child: ScaleTransition(
+          scale: scaleAnimation,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/playground/lib/home/custom_sheets/top_notification_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/top_notification_sheet_type.dart
@@ -1,0 +1,86 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class TopNotificationSheetType extends WoltModalType {
+  final EdgeInsetsDirectional padding;
+
+  const TopNotificationSheetType({
+    this.padding = const EdgeInsetsDirectional.all(32.0),
+  }) : super(
+          shapeBorder: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(24)),
+          ),
+          dismissDirection: WoltModalDismissDirection.up,
+          showDragHandle: false,
+          closeProgressThreshold: 0.8,
+        );
+
+  @override
+  String routeLabel(BuildContext context) {
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
+    return localizations.dialogLabel;
+  }
+
+  @override
+  BoxConstraints layoutModal(Size availableSize) {
+    final availableWidth = availableSize.width;
+    double width =
+        availableWidth > 523.0 ? 312.0 : availableWidth - padding.end;
+
+    if (availableWidth > 523.0) {
+      width = 312.0;
+    } else if (availableWidth > 240.0) {
+      width = 240.0;
+    } else {
+      width = availableWidth - padding.end;
+    }
+    return BoxConstraints(
+      minWidth: width,
+      maxWidth: width,
+      minHeight: 0,
+      maxHeight: availableSize.height * 0.6,
+    );
+  }
+
+  @override
+  Offset positionModal(
+      Size availableSize, Size modalContentSize, TextDirection textDirection) {
+    final xOffset =
+        max(0.0, (availableSize.width - modalContentSize.width) / 2);
+    final yOffset = padding.top;
+    return Offset(xOffset, yOffset);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final alphaAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: const Interval(0.0, 100.0 / 300.0, curve: Curves.linear),
+      reverseCurve: const Interval(100.0 / 250.0, 1.0, curve: Curves.linear),
+    ));
+
+    return FadeTransition(
+      opacity: alphaAnimation,
+      child: SlideTransition(
+        position: animation.drive(
+          Tween(
+            begin: const Offset(0.0, -1.0),
+            end: Offset.zero,
+          ).chain(CurveTween(curve: Curves.easeOutQuad)),
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -1,6 +1,9 @@
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:playground/home/custom_sheets/floating_bottom_sheet_type.dart';
+import 'package:playground/home/custom_sheets/top_notification_sheet_type.dart';
+import 'package:playground/home/pages/custom_sheet_pages/new_order_notification_page.dart';
 import 'package:playground/home/pages/root_sheet_page.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
@@ -30,165 +33,201 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Wolt Modal Sheet Playground'),
-        actions: [
-          WoltCircularElevatedButton(
-            onPressed: () {
-              timeDilation = _isSlowAnimation ? 1.0 : 8.0;
-              _isSlowAnimation = !_isSlowAnimation;
-            },
-            icon: Icons.speed_outlined,
-          ),
-          const SizedBox(width: 16),
-        ],
-      ),
-      body: Builder(builder: (context) {
-        return Align(
-          alignment: Alignment.center,
-          child: SizedBox(
-            width: _contentWidth,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Select responsiveness',
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium!
-                            .copyWith(fontWeight: FontWeight.bold),
-                      ),
-                      WoltSelectionList<_Responsiveness>.singleSelect(
-                        tilePadding:
-                            const EdgeInsetsDirectional.symmetric(vertical: 8),
-                        itemTileDataGroup: WoltSelectionListItemDataGroup(
-                          group: _Responsiveness.values
-                              .map(
-                                (e) => WoltSelectionListItemData(
-                                  title: e.label,
-                                  value: e,
-                                  isSelected: _selectedResponsiveness == e,
-                                ),
-                              )
-                              .toList(),
+        appBar: AppBar(
+          title: const Text('Wolt Modal Sheet Playground'),
+          actions: [
+            WoltCircularElevatedButton(
+              onPressed: () {
+                timeDilation = _isSlowAnimation ? 1.0 : 8.0;
+                _isSlowAnimation = !_isSlowAnimation;
+              },
+              icon: Icons.speed_outlined,
+            ),
+            const SizedBox(width: 16),
+          ],
+        ),
+        body: Builder(builder: (context) {
+          return Align(
+            alignment: Alignment.center,
+            child: SizedBox(
+              width: _contentWidth,
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Select responsiveness',
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium!
+                              .copyWith(fontWeight: FontWeight.bold),
                         ),
-                        onSelectionUpdateInSingleSelectionList: (selectedItem) {
-                          _selectedResponsiveness = selectedItem.value;
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Text('Light Theme'),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: Switch(
-                          value: !_isLightTheme,
-                          onChanged: (bool newValue) {
-                            _isLightTheme = !newValue;
-                            widget.onThemeBrightnessChanged(_isLightTheme);
+                        WoltSelectionList<_Responsiveness>.singleSelect(
+                          tilePadding: const EdgeInsetsDirectional.symmetric(
+                              vertical: 8),
+                          itemTileDataGroup: WoltSelectionListItemDataGroup(
+                            group: _Responsiveness.values
+                                .map(
+                                  (e) => WoltSelectionListItemData(
+                                    title: e.label,
+                                    value: e,
+                                    isSelected: _selectedResponsiveness == e,
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                          onSelectionUpdateInSingleSelectionList:
+                              (selectedItem) {
+                            _selectedResponsiveness = selectedItem.value;
                           },
                         ),
-                      ),
-                      const Text('Dark Theme'),
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Text('LTR'),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: Switch(
-                          value: _selectedDirection == TextDirection.rtl,
-                          onChanged: (bool newValue) {
-                            _selectedDirection = newValue
-                                ? TextDirection.rtl
-                                : TextDirection.ltr;
-                            widget.onDirectionalityChanged(_selectedDirection);
-                          },
-                        ),
-                      ),
-                      const Text('RTL'),
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  SizedBox(
-                    width: _contentWidth,
-                    child: WoltElevatedButton(
-                      onPressed: () {
-                        WoltModalSheet.show(
-                          context: context,
-                          modalTypeBuilder: (BuildContext context) {
-                            final woltDialogType = _isLightTheme
-                                ? const WoltDialogType()
-                                : const WoltDialogType().copyWith(
-                                    shapeBorder: const BeveledRectangleBorder(),
-                                  );
-                            final woltAlertDialogType = _isLightTheme
-                                ? const WoltAlertDialogType()
-                                : const WoltDialogType().copyWith(
-                                    shapeBorder: const BeveledRectangleBorder(),
-                                  );
-                            final bottomSheetType = _isLightTheme
-                                ? const WoltBottomSheetType()
-                                : const WoltBottomSheetType().copyWith(
-                                    shapeBorder: const BeveledRectangleBorder(),
-                                  );
-                            final sideSheetType = _isLightTheme
-                                ? const WoltSideSheetType()
-                                : const WoltSideSheetType().copyWith(
-                                    shapeBorder: const BeveledRectangleBorder(),
-                                  );
-                            switch (_selectedResponsiveness) {
-                              case _Responsiveness.alwaysDialog:
-                                return woltDialogType;
-                              case _Responsiveness.alwaysAlertDialog:
-                                return woltAlertDialogType;
-                              case _Responsiveness.alwaysBottomSheet:
-                                return bottomSheetType;
-                              case _Responsiveness.alwaysSideSheet:
-                                return sideSheetType;
-                              case _Responsiveness.auto:
-                                final width = MediaQuery.sizeOf(context).width;
-                                return width < _breakPoint
-                                    ? bottomSheetType
-                                    : woltDialogType;
-                            }
-                          },
-                          onModalDismissedWithDrag: () {
-                            debugPrint('Bottom sheet is dismissed with drag.');
-                            Navigator.of(context).pop();
-                          },
-                          onModalDismissedWithBarrierTap: () {
-                            debugPrint('Modal is dismissed with barrier tap.');
-                            Navigator.of(context).pop();
-                          },
-                          pageListBuilder: (BuildContext context) {
-                            return [RootSheetPage.build(context)];
-                          },
-                        );
-                      },
-                      child: const Text('Show Modal Sheet'),
+                      ],
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 4),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Text('Light Theme'),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Switch(
+                            value: !_isLightTheme,
+                            onChanged: (bool newValue) {
+                              _isLightTheme = !newValue;
+                              widget.onThemeBrightnessChanged(_isLightTheme);
+                            },
+                          ),
+                        ),
+                        const Text('Dark Theme'),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Text('LTR'),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Switch(
+                            value: _selectedDirection == TextDirection.rtl,
+                            onChanged: (bool newValue) {
+                              _selectedDirection = newValue
+                                  ? TextDirection.rtl
+                                  : TextDirection.ltr;
+                              widget
+                                  .onDirectionalityChanged(_selectedDirection);
+                            },
+                          ),
+                        ),
+                        const Text('RTL'),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    SizedBox(
+                      width: _contentWidth,
+                      child: WoltElevatedButton(
+                        onPressed: () {
+                          WoltModalSheet.show(
+                            context: context,
+                            modalTypeBuilder: (BuildContext context) {
+                              final woltDialogType = _isLightTheme
+                                  ? const WoltDialogType()
+                                  : const WoltDialogType().copyWith(
+                                      shapeBorder:
+                                          const BeveledRectangleBorder(),
+                                    );
+                              final woltAlertDialogType = _isLightTheme
+                                  ? const WoltAlertDialogType()
+                                  : const WoltDialogType().copyWith(
+                                      shapeBorder:
+                                          const BeveledRectangleBorder(),
+                                    );
+                              final bottomSheetType = _isLightTheme
+                                  ? const WoltBottomSheetType()
+                                  : const WoltBottomSheetType().copyWith(
+                                      shapeBorder:
+                                          const BeveledRectangleBorder(),
+                                    );
+                              final sideSheetType = _isLightTheme
+                                  ? const WoltSideSheetType()
+                                  : const WoltSideSheetType().copyWith(
+                                      shapeBorder:
+                                          const BeveledRectangleBorder(),
+                                    );
+                              switch (_selectedResponsiveness) {
+                                case _Responsiveness.alwaysDialog:
+                                  return woltDialogType;
+                                case _Responsiveness.alwaysAlertDialog:
+                                  return woltAlertDialogType;
+                                case _Responsiveness.alwaysBottomSheet:
+                                  return bottomSheetType;
+                                case _Responsiveness.alwaysSideSheet:
+                                  return sideSheetType;
+                                case _Responsiveness.auto:
+                                  final width =
+                                      MediaQuery.sizeOf(context).width;
+                                  return width < _breakPoint
+                                      ? bottomSheetType
+                                      : woltDialogType;
+                              }
+                            },
+                            onModalDismissedWithDrag: () {
+                              debugPrint(
+                                  'Bottom sheet is dismissed with drag.');
+                              Navigator.of(context).pop();
+                            },
+                            onModalDismissedWithBarrierTap: () {
+                              debugPrint(
+                                  'Modal is dismissed with barrier tap.');
+                              Navigator.of(context).pop();
+                            },
+                            pageListBuilder: (BuildContext context) {
+                              return [RootSheetPage.build(context)];
+                            },
+                          );
+                        },
+                        child: const Text('Show Modal Sheet'),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: _contentWidth,
+                      child: WoltElevatedButton(
+                        onPressed: () {
+                          WoltModalSheet.show(
+                            barrierDismissible: false,
+                            context: context,
+                            modalTypeBuilder: (_) =>
+                                const TopNotificationSheetType(),
+                            pageListBuilder: (_) =>
+                                [NewOrderNotificationPage()],
+                          );
+                        },
+                        child: const Text('Show Custom Modal Sheet'),
+                      ),
+                    )
+                  ],
+                ),
               ),
             ),
-          ),
-        );
-      }),
-    );
+          );
+        }),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            WoltModalSheet.show(
+              barrierDismissible: false,
+              context: context,
+              modalTypeBuilder: (_) => const FloatingBottomSheetType(),
+              pageListBuilder: (_) => [NewOrderNotificationPage()],
+            );
+          },
+          child: const Icon(Icons.notifications_active),
+        ));
   }
 }
 

--- a/playground/lib/home/pages/custom_sheet_pages/adjust_time_notification_page.dart
+++ b/playground/lib/home/pages/custom_sheet_pages/adjust_time_notification_page.dart
@@ -1,0 +1,108 @@
+import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+enum AdjustTimeGridItemColors {
+  normal(
+    foregroundColor: WoltColors.blue,
+    backgroundColor: WoltColors.blue8,
+  ),
+  warning(
+    foregroundColor: WoltColors.yellow,
+    backgroundColor: WoltColors.yellow8,
+  ),
+  alert(
+    foregroundColor: WoltColors.red,
+    backgroundColor: WoltColors.red8,
+  );
+
+  const AdjustTimeGridItemColors({
+    required this.foregroundColor,
+    required this.backgroundColor,
+  });
+
+  final Color foregroundColor;
+  final Color backgroundColor;
+}
+
+class AdjustTimeNotificationPage extends WoltModalSheetPage {
+  AdjustTimeNotificationPage()
+      : super(
+          topBarTitle: const ModalSheetTopBarTitle('Adjust time'),
+          isTopBarLayerAlwaysVisible: true,
+          trailingNavBarWidget: const WoltModalSheetCloseButton(),
+          leadingNavBarWidget: const WoltModalSheetBackButton(),
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: GridView.builder(
+              padding: EdgeInsets.zero,
+              key: const Key('confirmTaskBottomSheep-suggestedTimeGrid'),
+              physics: const NeverScrollableScrollPhysics(),
+              shrinkWrap: true,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+                mainAxisExtent: 72,
+              ),
+              itemBuilder: (context, index) => _items[index],
+              itemCount: _items.length,
+            ),
+          ),
+        );
+
+  static const pageId = 'adjust_time_notification_page';
+
+  /// 9 items with different priority levels
+  static const List<Widget> _items = [
+    _GridItem(timeInMinutes: 26, colors: AdjustTimeGridItemColors.normal),
+    _GridItem(timeInMinutes: 30, colors: AdjustTimeGridItemColors.normal),
+    _GridItem(timeInMinutes: 34, colors: AdjustTimeGridItemColors.normal),
+    _GridItem(timeInMinutes: 38, colors: AdjustTimeGridItemColors.normal),
+    _GridItem(timeInMinutes: 42, colors: AdjustTimeGridItemColors.normal),
+    _GridItem(timeInMinutes: 46, colors: AdjustTimeGridItemColors.warning),
+    _GridItem(timeInMinutes: 50, colors: AdjustTimeGridItemColors.warning),
+    _GridItem(timeInMinutes: 54, colors: AdjustTimeGridItemColors.alert),
+    _GridItem(timeInMinutes: 58, colors: AdjustTimeGridItemColors.alert),
+  ];
+}
+
+class _GridItem extends StatelessWidget {
+  const _GridItem({
+    required this.colors,
+    required this.timeInMinutes,
+  });
+
+  final AdjustTimeGridItemColors colors;
+  final int timeInMinutes;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Material(
+      color: colors.backgroundColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      clipBehavior: Clip.antiAliasWithSaveLayer,
+      child: InkWell(
+        onTap: Navigator.of(context).pop,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              timeInMinutes.toString(),
+              style: textTheme.headlineSmall!.copyWith(
+                color: colors.foregroundColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(
+              'minutes',
+              style: textTheme.labelMedium!
+                  .copyWith(color: colors.foregroundColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/playground/lib/home/pages/custom_sheet_pages/new_order_notification_page.dart
+++ b/playground/lib/home/pages/custom_sheet_pages/new_order_notification_page.dart
@@ -1,0 +1,61 @@
+import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/material.dart';
+import 'package:playground/home/pages/custom_sheet_pages/adjust_time_notification_page.dart';
+import 'package:playground/home/pages/custom_sheet_pages/reject_order_notification_page.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class NewOrderNotificationPage extends WoltModalSheetPage {
+  NewOrderNotificationPage()
+      : super(
+          hasTopBarLayer: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Builder(builder: (context) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const ModalSheetTitle(
+                    'Can you have the order ready in 34 minutes?',
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  const ModalSheetContentText(
+                    'Suggested time is based on your average preparation time.',
+                  ),
+                  const SizedBox(height: 16),
+                  WoltElevatedButton(
+                    height: _buttonHeight,
+                    onPressed: Navigator.of(context).pop,
+                    child: const Text('Yes'),
+                  ),
+                  const SizedBox(height: 4),
+                  WoltElevatedButton(
+                    height: _buttonHeight,
+                    onPressed: () {
+                      WoltModalSheet.of(context)
+                        ..addOrReplacePage(AdjustTimeNotificationPage())
+                        ..showNext();
+                    },
+                    theme: WoltElevatedButtonTheme.secondary,
+                    child: const Text('Adjust time'),
+                  ),
+                  const SizedBox(height: 4),
+                  WoltElevatedButton(
+                    height: _buttonHeight,
+                    onPressed: () {
+                      WoltModalSheet.of(context)
+                        ..addOrReplacePage(RejectOrderNotificationPage())
+                        ..showNext();
+                    },
+                    theme: WoltElevatedButtonTheme.secondary,
+                    colorName: WoltColorName.red,
+                    child: const Text('Reject order'),
+                  ),
+                ],
+              );
+            }),
+          ),
+        );
+
+  static const double _buttonHeight = 24.0;
+}

--- a/playground/lib/home/pages/custom_sheet_pages/reject_order_notification_page.dart
+++ b/playground/lib/home/pages/custom_sheet_pages/reject_order_notification_page.dart
@@ -1,0 +1,85 @@
+import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+enum RejectOrderReason {
+  runOutOfCoffee(
+    title: 'Run out of coffee',
+    subtitle: 'One or more items are out of stock',
+    leadingIcon: Icons.search_off,
+  ),
+  tooBusy(
+    title: 'Too busy',
+    subtitle: 'There is not enough time to prepare the order',
+    leadingIcon: Icons.people,
+  ),
+  closingSoon(
+    title: 'Closing soon',
+    subtitle: 'Not enough time to prepare the order before closing',
+    leadingIcon: Icons.timelapse,
+  );
+
+  const RejectOrderReason({
+    required this.leadingIcon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData leadingIcon;
+  final String title;
+  final String subtitle;
+}
+
+final _buttonEnabledListener = ValueNotifier(false);
+
+class RejectOrderNotificationPage extends WoltModalSheetPage {
+  RejectOrderNotificationPage()
+      : super(
+          stickyActionBar: ValueListenableBuilder<bool>(
+            valueListenable: _buttonEnabledListener,
+            builder: (_, isEnabled, __) {
+              return Builder(builder: (context) {
+                return Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: WoltElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      _buttonEnabledListener.value = false;
+                    },
+                    theme: WoltElevatedButtonTheme.secondary,
+                    colorName: WoltColorName.red,
+                    enabled: isEnabled,
+                    height: 24.0,
+                    child: const Text('Reject'),
+                  ),
+                );
+              });
+            },
+          ),
+          isTopBarLayerAlwaysVisible: true,
+          topBarTitle: const ModalSheetTopBarTitle('Reject reason'),
+          trailingNavBarWidget: const WoltModalSheetCloseButton(),
+          leadingNavBarWidget: const WoltModalSheetBackButton(),
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 72),
+            child: WoltSelectionList<RejectOrderReason>.singleSelect(
+              itemTileDataGroup: WoltSelectionListItemDataGroup(
+                group: RejectOrderReason.values
+                    .map(
+                      (e) => WoltSelectionListItemData(
+                        title: e.title,
+                        subtitle: e.subtitle,
+                        leadingIcon: e.leadingIcon,
+                        value: e,
+                        isSelected: false,
+                      ),
+                    )
+                    .toList(),
+              ),
+              onSelectionUpdateInSingleSelectionList: (selectedItemData) {
+                _buttonEnabledListener.value = selectedItemData.isSelected;
+              },
+            ),
+          ),
+        );
+}

--- a/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
+++ b/playground/lib/home/pages/sheet_page_with_no_page_title_and_no_top_bar.dart
@@ -6,7 +6,7 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 class SheetPageWithNoPageTitleNoTopBar {
   SheetPageWithNoPageTitleNoTopBar._();
 
-  static const ModalPageName pageId = ModalPageName.lazyLoadingList;
+  static const ModalPageName pageId = ModalPageName.noTitleNoTopBar;
 
   static WoltModalSheetPage build({
     bool isLastPage = true,

--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -69,30 +69,24 @@ class _DemoAppState extends State<DemoApp> {
       theme: ThemeData.light().copyWith(
         brightness: Brightness.light,
         inputDecorationTheme: inputDecorationTheme,
-        primaryColor: WoltColors.blue,
         useMaterial3: true,
-        switchTheme: SwitchThemeData(
-          thumbColor: MaterialStateProperty.all(WoltColors.blue),
-          trackColor: MaterialStateProperty.all(WoltColors.blue16),
-        ),
+        colorScheme: ColorScheme.fromSeed(seedColor: WoltColors.blue),
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
-            modalBarrierColor: Colors.black54,
+            modalBarrierColor: Color(0x52000000),
+            surfaceTintColor: Colors.transparent,
           ),
         ],
       ),
       darkTheme: ThemeData.dark(useMaterial3: true).copyWith(
         brightness: Brightness.dark,
         inputDecorationTheme: inputDecorationTheme,
-        primaryColor: WoltColors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF009DE0)),
         useMaterial3: true,
-        switchTheme: SwitchThemeData(
-          thumbColor: MaterialStateProperty.all(WoltColors.blue),
-          trackColor: MaterialStateProperty.all(WoltColors.blue16),
-        ),
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
-            modalBarrierColor: Colors.white12,
+            backgroundColor: Color(0xFF242424),
+            modalBarrierColor: Color(0x52000000),
             sabGradientColor: _darkSabGradientColor,
           ),
         ],


### PR DESCRIPTION
## Description

This PR adds two examples for adding custom modal types:

| Floating Bottom Sheet Type |
|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/e54f550b-9968-491d-8ad5-b3ef57bded2d"> |  

| Top Notification Sheet Type |
|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/5af58fa5-cd15-41e3-af3e-e5245907b856"> |  

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/woltapp/wolt_modal_sheet/issues). Indicate, which of these issues are resolved or fixed by this PR.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

