### PR TITLE
Fix: Prevent dismiss on barrier tap for alert dialog

### DIFF
--- a/lib/src/modal_type/wolt_alert_dialog_type.dart
+++ b/lib/src/modal_type/wolt_alert_dialog_type.dart
@@ -5,7 +5,7 @@ import 'package:wolt_modal_sheet/src/utils/wolt_breakpoints.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class WoltAlertDialogType extends WoltDialogType {
-  const WoltAlertDialogType();
+  const WoltAlertDialogType() : super(barrierDismissible: false);
 
   @override
   BoxConstraints layoutModal(Size availableSize) {

--- a/lib/src/modal_type/wolt_bottom_sheet_type.dart
+++ b/lib/src/modal_type/wolt_bottom_sheet_type.dart
@@ -19,6 +19,7 @@ class WoltBottomSheetType extends WoltModalType {
     Duration transitionDuration = _defaultEnterDuration,
     Duration reverseTransitionDuration = _defaultExitDuration,
     minFlingVelocity = 700.0,
+    bool? barrierDismissible,
   }) : super(
           shapeBorder: shapeBorder,
           forceMaxHeight: forceMaxHeight,
@@ -27,6 +28,7 @@ class WoltBottomSheetType extends WoltModalType {
           dismissDirection: dismissDirection,
           minFlingVelocity: minFlingVelocity,
           showDragHandle: showDragHandle,
+          barrierDismissible: barrierDismissible,
         );
 
   static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
@@ -176,6 +178,7 @@ class WoltBottomSheetType extends WoltModalType {
     Duration? reverseTransitionDuration,
     WoltModalDismissDirection? dismissDirection,
     double? minFlingVelocity,
+    bool? barrierDismissible,
   }) {
     return WoltBottomSheetType(
       shapeBorder: shapeBorder ?? this.shapeBorder,
@@ -186,6 +189,7 @@ class WoltBottomSheetType extends WoltModalType {
           reverseTransitionDuration ?? this.reverseTransitionDuration,
       dismissDirection: dismissDirection ?? this.dismissDirection,
       minFlingVelocity: minFlingVelocity ?? this.minFlingVelocity,
+      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
     );
   }
 }

--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -15,12 +15,14 @@ class WoltDialogType extends WoltModalType {
     bool forceMaxHeight = false,
     Duration transitionDuration = _defaultEnterDuration,
     Duration reverseTransitionDuration = _defaultExitDuration,
+    bool? barrierDismissible,
   }) : super(
           shapeBorder: shapeBorder,
           forceMaxHeight: forceMaxHeight,
           transitionDuration: transitionDuration,
           reverseTransitionDuration: reverseTransitionDuration,
           showDragHandle: false,
+          barrierDismissible: barrierDismissible,
         );
 
   static const Duration _defaultEnterDuration = Duration(milliseconds: 300);
@@ -145,6 +147,7 @@ class WoltDialogType extends WoltModalType {
     bool? forceMaxHeight,
     Duration? transitionDuration,
     Duration? reverseTransitionDuration,
+    bool? barrierDismissible,
   }) {
     return WoltDialogType(
       shapeBorder: shapeBorder ?? this.shapeBorder,
@@ -152,6 +155,7 @@ class WoltDialogType extends WoltModalType {
       transitionDuration: transitionDuration ?? this.transitionDuration,
       reverseTransitionDuration:
           reverseTransitionDuration ?? this.reverseTransitionDuration,
+      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
     );
   }
 

--- a/lib/src/modal_type/wolt_modal_type.dart
+++ b/lib/src/modal_type/wolt_modal_type.dart
@@ -23,6 +23,7 @@ abstract class WoltModalType {
     this.reverseTransitionDuration = const Duration(milliseconds: 300),
     this.minFlingVelocity = 700.0,
     this.closeProgressThreshold = 0.5,
+    this.barrierDismissible,
   });
 
   /// Creates the default bottom sheet modal.
@@ -82,6 +83,9 @@ abstract class WoltModalType {
   /// - A higher value (closer to 1.0) means the modal will be easier to dismiss.
   /// - A lower value (closer to 0.0) means the modal will be harder to dismiss
   final double closeProgressThreshold;
+
+  // Whether the modal can be dismissed by tapping the barrier.
+  final bool? barrierDismissible;
 
   /// Defines the constraints for the modal based on the available screen size.
   ///

--- a/lib/src/modal_type/wolt_side_sheet_type.dart
+++ b/lib/src/modal_type/wolt_side_sheet_type.dart
@@ -15,6 +15,7 @@ class WoltSideSheetType extends WoltModalType {
     WoltModalDismissDirection? dismissDirection =
         WoltModalDismissDirection.endToStart,
     double minFlingVelocity = 365.0,
+    bool? barrierDismissible,
   }) : super(
           shapeBorder: shapeBorder,
           showDragHandle: false,
@@ -23,6 +24,7 @@ class WoltSideSheetType extends WoltModalType {
           reverseTransitionDuration: reverseTransitionDuration,
           dismissDirection: dismissDirection,
           minFlingVelocity: minFlingVelocity,
+          barrierDismissible: barrierDismissible,
         );
 
   static const Duration _defaultEnterDuration = Duration(milliseconds: 300);
@@ -187,6 +189,7 @@ class WoltSideSheetType extends WoltModalType {
     Duration? reverseTransitionDuration,
     WoltModalDismissDirection? dismissDirection,
     double? minFlingVelocity,
+    bool? barrierDismissible,
   }) {
     return WoltSideSheetType(
       shapeBorder: shapeBorder ?? this.shapeBorder,
@@ -196,6 +199,7 @@ class WoltSideSheetType extends WoltModalType {
           reverseTransitionDuration ?? this.reverseTransitionDuration,
       dismissDirection: dismissDirection ?? this.dismissDirection,
       minFlingVelocity: minFlingVelocity ?? this.minFlingVelocity,
+      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
     );
   }
 }

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -22,7 +22,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
         _showDragHandle = showDragHandle,
         _useSafeArea = useSafeArea ?? true,
         _transitionAnimationController = transitionAnimationController,
-        _barrierDismissible = barrierDismissible ?? true,
+        _barrierDismissible = barrierDismissible,
         _modalTypeBuilder = modalTypeBuilder,
         super(settings: routeSettings);
 
@@ -34,7 +34,7 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
 
   final WoltModalTypeBuilder? _modalTypeBuilder;
 
-  late final bool _barrierDismissible;
+  final bool? _barrierDismissible;
 
   final VoidCallback? onModalDismissedWithBarrierTap;
 
@@ -58,7 +58,10 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
   final AnimationController? _transitionAnimationController;
 
   @override
-  bool get barrierDismissible => _barrierDismissible;
+  bool get barrierDismissible =>
+      _barrierDismissible ??
+      _determineCurrentModalType(navigator!.context).barrierDismissible ??
+      true;
 
   /// The value of false was chosen to indicate that the modal route does not fully obscure the
   /// underlying content. This allows for a translucent effect, where the content beneath the

--- a/playground/lib/home/custom_sheets/top_notification_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/top_notification_sheet_type.dart
@@ -15,6 +15,7 @@ class TopNotificationSheetType extends WoltModalType {
           dismissDirection: WoltModalDismissDirection.up,
           showDragHandle: false,
           closeProgressThreshold: 0.8,
+          barrierDismissible: false,
         );
 
   @override

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -200,7 +200,6 @@ class _HomeScreenState extends State<HomeScreen> {
                       child: WoltElevatedButton(
                         onPressed: () {
                           WoltModalSheet.show(
-                            barrierDismissible: false,
                             context: context,
                             modalTypeBuilder: (_) =>
                                 const TopNotificationSheetType(),
@@ -220,7 +219,6 @@ class _HomeScreenState extends State<HomeScreen> {
         floatingActionButton: FloatingActionButton(
           onPressed: () {
             WoltModalSheet.show(
-              barrierDismissible: false,
               context: context,
               modalTypeBuilder: (_) => const FloatingBottomSheetType(),
               pageListBuilder: (_) => [NewOrderNotificationPage()],


### PR DESCRIPTION
## Description

This PR addresses an issue where alert dialogs could be dismissed by tapping the barrier (the area outside the dialog). This behavior was unintended for alert dialogs, which typically require explicit user action to dismiss.

| Before Dismiss on Barrier | After Dismiss on Barrier|
|--------|--------|
| <video src= "https://github.com/woltapp/wolt_modal_sheet/assets/13484562/73ae450a-3ded-420d-9106-86ce9144e281"> | <video src= "https://github.com/woltapp/wolt_modal_sheet/assets/13484562/b49a4b5d-b796-470a-91fc-24934f9a292a"> |

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.