### PR TITLE
Fix: Wolt dialog type position animation updated

### DIFF
--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -120,8 +120,14 @@ class WoltDialogType extends WoltModalType {
     const enteringInterval = Interval(0.0, 100.0 / 300.0, curve: Curves.linear);
     const exitingInterval = Interval(100.0 / 250.0, 1.0, curve: Curves.linear);
 
+    const enteringCubic = Cubic(0.2, 0.6, 0.4, 1.0);
+    const exitingCubic = Cubic(0.5, 0, 0.7, 0.2);
+
     final interval = isClosing ? exitingInterval : enteringInterval;
     final reverseInterval = isClosing ? enteringInterval : exitingInterval;
+
+    final cubic = isClosing ? exitingCubic : enteringCubic;
+    final reverseCubic = isClosing ? enteringCubic : exitingCubic;
 
     final alphaAnimation = Tween<double>(
       begin: 0.0,
@@ -132,9 +138,24 @@ class WoltDialogType extends WoltModalType {
       reverseCurve: reverseInterval,
     ));
 
+    // Position animation for entering (96px upwards) and exiting (96px downwards)
+    final positionAnimation = Tween<Offset>(
+      end: const Offset(0.0, 0.0),
+      begin: const Offset(0.0, 0.05),
+    ).animate(
+      CurvedAnimation(
+        parent: animation,
+        curve: cubic,
+        reverseCurve: reverseCubic,
+      ),
+    );
+
     return FadeTransition(
       opacity: alphaAnimation,
-      child: child,
+      child: SlideTransition(
+        position: positionAnimation,
+        child: child,
+      ),
     );
   }
 


### PR DESCRIPTION
## Description

This PR adds position animations for dialogs when they appear and disappear. The animation creates a more polished and engaging user experience by adding a slight vertical movement to the dialog. This was added according to Wolt Design System.

| Before Dialog | After Dialog |
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13484562/955b87d5-e72a-4524-ae0a-d7692486225a"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13484562/6d71e121-2f0d-47c5-bfcd-aa9380a82a2b"> |
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13484562/9e0d1168-567b-4cda-b67c-faf777354f65"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13484562/f4ac7eeb-995e-42da-9e66-5bdd6ac3ad6e"> | 


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
