### PR TITLE
Adjust dialog enter animation distance

### DIFF
--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -141,7 +141,7 @@ class WoltDialogType extends WoltModalType {
     // Position animation for entering (96px upwards) and exiting (96px downwards)
     final positionAnimation = Tween<Offset>(
       end: const Offset(0.0, 0.0),
-      begin: const Offset(0.0, 0.05),
+      begin: Offset(0.0, isClosing ? 0.05 : 0.1),
     ).animate(
       CurvedAnimation(
         parent: animation,


### PR DESCRIPTION
## Description

After design review with motion designer at Wolt, we decided to adjust the enter animation y-position distance. It is longer distance now.

| Before | After |
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/519865ab-d2db-4d7b-bbbd-8d8c00608c6d"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/c1d11150-1c98-47da-9abf-59bf28230f71"> | 

