### PR TITLE
Feature: Extend close progress threshold for different types

### DIFF
--- a/lib/src/modal_type/wolt_bottom_sheet_type.dart
+++ b/lib/src/modal_type/wolt_bottom_sheet_type.dart
@@ -19,8 +19,8 @@ class WoltBottomSheetType extends WoltModalType {
     Duration transitionDuration = _defaultEnterDuration,
     Duration reverseTransitionDuration = _defaultExitDuration,
     minFlingVelocity = 700.0,
-    bool? barrierDismissible,
     closeProgressThreshold = 0.5,
+    bool? barrierDismissible,
   }) : super(
           shapeBorder: shapeBorder,
           forceMaxHeight: forceMaxHeight,
@@ -28,9 +28,9 @@ class WoltBottomSheetType extends WoltModalType {
           reverseTransitionDuration: reverseTransitionDuration,
           dismissDirection: dismissDirection,
           minFlingVelocity: minFlingVelocity,
+          closeProgressThreshold: closeProgressThreshold,
           showDragHandle: showDragHandle,
           barrierDismissible: barrierDismissible,
-          closeProgressThreshold: closeProgressThreshold,
         );
 
   static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
@@ -180,8 +180,8 @@ class WoltBottomSheetType extends WoltModalType {
     Duration? reverseTransitionDuration,
     WoltModalDismissDirection? dismissDirection,
     double? minFlingVelocity,
-    bool? barrierDismissible,
     double? closeProgressThreshold,
+    bool? barrierDismissible,
   }) {
     return WoltBottomSheetType(
       shapeBorder: shapeBorder ?? this.shapeBorder,
@@ -192,9 +192,9 @@ class WoltBottomSheetType extends WoltModalType {
           reverseTransitionDuration ?? this.reverseTransitionDuration,
       dismissDirection: dismissDirection ?? this.dismissDirection,
       minFlingVelocity: minFlingVelocity ?? this.minFlingVelocity,
-      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
       closeProgressThreshold:
           closeProgressThreshold ?? this.closeProgressThreshold,
+      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
     );
   }
 }

--- a/lib/src/modal_type/wolt_bottom_sheet_type.dart
+++ b/lib/src/modal_type/wolt_bottom_sheet_type.dart
@@ -20,6 +20,7 @@ class WoltBottomSheetType extends WoltModalType {
     Duration reverseTransitionDuration = _defaultExitDuration,
     minFlingVelocity = 700.0,
     bool? barrierDismissible,
+    closeProgressThreshold = 0.5,
   }) : super(
           shapeBorder: shapeBorder,
           forceMaxHeight: forceMaxHeight,
@@ -29,6 +30,7 @@ class WoltBottomSheetType extends WoltModalType {
           minFlingVelocity: minFlingVelocity,
           showDragHandle: showDragHandle,
           barrierDismissible: barrierDismissible,
+          closeProgressThreshold: closeProgressThreshold,
         );
 
   static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
@@ -179,6 +181,7 @@ class WoltBottomSheetType extends WoltModalType {
     WoltModalDismissDirection? dismissDirection,
     double? minFlingVelocity,
     bool? barrierDismissible,
+    double? closeProgressThreshold,
   }) {
     return WoltBottomSheetType(
       shapeBorder: shapeBorder ?? this.shapeBorder,
@@ -190,6 +193,8 @@ class WoltBottomSheetType extends WoltModalType {
       dismissDirection: dismissDirection ?? this.dismissDirection,
       minFlingVelocity: minFlingVelocity ?? this.minFlingVelocity,
       barrierDismissible: barrierDismissible ?? this.barrierDismissible,
+      closeProgressThreshold:
+          closeProgressThreshold ?? this.closeProgressThreshold,
     );
   }
 }

--- a/lib/src/modal_type/wolt_side_sheet_type.dart
+++ b/lib/src/modal_type/wolt_side_sheet_type.dart
@@ -15,6 +15,7 @@ class WoltSideSheetType extends WoltModalType {
     WoltModalDismissDirection? dismissDirection =
         WoltModalDismissDirection.endToStart,
     double minFlingVelocity = 365.0,
+    double closeProgressThreshold = 0.5,
     bool? barrierDismissible,
   }) : super(
           shapeBorder: shapeBorder,
@@ -24,6 +25,7 @@ class WoltSideSheetType extends WoltModalType {
           reverseTransitionDuration: reverseTransitionDuration,
           dismissDirection: dismissDirection,
           minFlingVelocity: minFlingVelocity,
+          closeProgressThreshold: closeProgressThreshold,
           barrierDismissible: barrierDismissible,
         );
 
@@ -189,6 +191,7 @@ class WoltSideSheetType extends WoltModalType {
     Duration? reverseTransitionDuration,
     WoltModalDismissDirection? dismissDirection,
     double? minFlingVelocity,
+    double? closeProgressThreshold,
     bool? barrierDismissible,
   }) {
     return WoltSideSheetType(
@@ -199,6 +202,8 @@ class WoltSideSheetType extends WoltModalType {
           reverseTransitionDuration ?? this.reverseTransitionDuration,
       dismissDirection: dismissDirection ?? this.dismissDirection,
       minFlingVelocity: minFlingVelocity ?? this.minFlingVelocity,
+      closeProgressThreshold:
+          closeProgressThreshold ?? this.closeProgressThreshold,
       barrierDismissible: barrierDismissible ?? this.barrierDismissible,
     );
   }


### PR DESCRIPTION
## Description

closeProgressThreshold is currently only available in WoltModalType class. Extending the defined modal types do not allow overriding this value. We should add this value to constructor of WoltBottomSheetType class

## Related Issues

[Add closeProgressThreshold to default modal type constructor methods](https://github.com/woltapp/wolt_modal_sheet/issues/253)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- x ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

