### PR TITLE
Fix: Dialog and bottom sheet minimum height is not respected to modal content min height

### DIFF
--- a/lib/src/modal_type/wolt_bottom_sheet_type.dart
+++ b/lib/src/modal_type/wolt_bottom_sheet_type.dart
@@ -65,7 +65,7 @@ class WoltBottomSheetType extends WoltModalType {
     return BoxConstraints(
       minWidth: availableSize.width,
       maxWidth: availableSize.width,
-      minHeight: availableSize.height * 0.4,
+      minHeight: 0,
       maxHeight: availableSize.height * 0.9,
     );
   }

--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -69,14 +69,14 @@ class WoltDialogType extends WoltModalType {
       return BoxConstraints(
         minWidth: width,
         maxWidth: width,
-        minHeight: 360,
+        minHeight: 0,
         maxHeight: max(360, availableHeight * 0.8),
       );
     }
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,
-      minHeight: availableHeight * 0.8,
+      minHeight: 0,
       maxHeight: availableHeight * 0.8,
     );
   }

--- a/playground/lib/home/pages/modal_page_name.dart
+++ b/playground/lib/home/pages/modal_page_name.dart
@@ -7,5 +7,6 @@ enum ModalPageName {
   customTopBar,
   updatePage,
   inAppNavigation,
+  minHeight,
   flexibleLayout,
 }

--- a/playground/lib/home/pages/root_sheet_page.dart
+++ b/playground/lib/home/pages/root_sheet_page.dart
@@ -2,6 +2,7 @@ import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
 import 'package:playground/home/pages/modal_page_name.dart';
 import 'package:playground/home/pages/sheet_page_with_custom_top_bar.dart';
+import 'package:playground/home/pages/sheet_page_with_min_height.dart';
 import 'package:playground/home/pages/sheet_page_with_update_page_method.dart';
 import 'package:playground/home/pages/sheet_page_with_forced_max_height.dart';
 import 'package:playground/home/pages/sheet_page_with_hero_image.dart';
@@ -27,6 +28,7 @@ class RootSheetPage {
         SheetPageWithHeroImage.build(isLastPage: false),
         SheetPageWithLazyList.build(isLastPage: false),
         SheetPageWithTextField.build(isLastPage: false),
+        SheetPageWithMinHeight.build(isLastPage: false),
         SheetPageWithInAppNavigation.build(isLastPage: false),
         SheetPageWithCustomTopBar.build(isLastPage: false),
         SheetPageWithNoPageTitleNoTopBar.build(isLastPage: false),
@@ -76,6 +78,11 @@ class RootSheetPage {
                     WoltSelectionListItemData(
                       title: 'Page with lazy loading list',
                       value: SheetPageWithLazyList.pageId,
+                      isSelected: false,
+                    ),
+                    WoltSelectionListItemData(
+                      title: 'Page with min height constraint',
+                      value: SheetPageWithMinHeight.pageId,
                       isSelected: false,
                     ),
                     WoltSelectionListItemData(
@@ -131,6 +138,9 @@ class RootSheetPage {
                       break;
                     case ModalPageName.textField:
                       destinationPage = SheetPageWithTextField.build();
+                      break;
+                    case ModalPageName.minHeight:
+                      destinationPage = SheetPageWithMinHeight.build();
                       break;
                     case ModalPageName.noTitleNoTopBar:
                       destinationPage =

--- a/playground/lib/home/pages/sheet_page_with_min_height.dart
+++ b/playground/lib/home/pages/sheet_page_with_min_height.dart
@@ -1,0 +1,33 @@
+import 'package:demo_ui_components/demo_ui_components.dart';
+import 'package:flutter/material.dart';
+import 'package:playground/home/pages/modal_page_name.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class SheetPageWithMinHeight {
+  SheetPageWithMinHeight._();
+
+  static const ModalPageName pageId = ModalPageName.minHeight;
+
+  static WoltModalSheetPage build({bool isLastPage = true}) {
+    return WoltModalSheetPage(
+      id: pageId,
+      hasTopBarLayer: false,
+      stickyActionBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Builder(builder: (context) {
+          return WoltElevatedButton(
+            onPressed: isLastPage
+                ? Navigator.of(context).pop
+                : WoltModalSheet.of(context).showNext,
+            child: Text(isLastPage ? "Close" : "Next"),
+          );
+        }),
+      ),
+      child: const Padding(
+        padding: EdgeInsets.only(bottom: 100, top: 16, left: 16, right: 16),
+        child: ModalSheetContentText(
+            'This page is added to test the constraints for minimum height.'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Dialog and bottom sheet min height is not respected to modal constraints. We added this test case to playground app.

The root cause is that the modal content constraints are calculated without consideration of the available space and it is independent of the modal constraints. When the min height is more than the content height, we currently don't fill the space to min height. It could be added as a feature in later updates, but adding this feature now will complicate the internal implementation. We can address this issue when we use the page as widget.

| Before | After |
|--------|--------|
| <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/372e5dc2-2cc9-40c1-865f-638c5daca5ee"> | <video src="https://github.com/woltapp/wolt_modal_sheet/assets/13782003/5545b2bc-ddab-4813-a600-dc1859d3f778"> | 

## Related Issues

Issue #259 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

