### PR TITLE
feat: Add Attached Sheet to Playground

### DIFF
--- a/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+
+class AttachedFloatingBottomSheetType extends WoltModalType {
+  static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
+  static const Duration _defaultExitDuration = Duration(milliseconds: 300);
+
+  AttachedFloatingBottomSheetType({
+    required GlobalKey anchorKey,
+    this.alignment = Alignment.center,
+  }) : super(
+          shapeBorder: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(28.0)),
+          ),
+          showDragHandle: false,
+          dismissDirection: WoltModalDismissDirection.down,
+          transitionDuration: _defaultEnterDuration,
+          reverseTransitionDuration: _defaultExitDuration,
+        ) {
+    _anchorPosition =
+        (anchorKey.currentContext?.findRenderObject() as RenderBox?)
+            ?.localToGlobal(Offset.zero);
+  }
+
+  late final Offset? _anchorPosition;
+  final Alignment alignment;
+
+  @override
+  Offset positionModal(
+      Size availableSize, Size modalContentSize, TextDirection textDirection) {
+    final anchorPosition = _anchorPosition;
+    if (anchorPosition == null) {
+      // Return the Center Offset by the size of the modal content
+      return availableSize.center(Offset.zero) -
+          Offset(modalContentSize.width, modalContentSize.height) / 2;
+    } else {
+      final offsetPosition = anchorPosition -
+          Offset(modalContentSize.width, modalContentSize.height) / 2 -
+          Offset(alignment.x / 2 * modalContentSize.width,
+              alignment.y / 2 * modalContentSize.height);
+
+      return offsetPosition;
+    }
+  }
+
+  @override
+  String routeLabel(BuildContext context) {
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
+    return localizations.bottomSheetLabel;
+  }
+
+  @override
+  BoxConstraints layoutModal(Size availableSize) {
+    const padding = 32.0;
+    final availableWidth = availableSize.width;
+    double width = availableWidth > 523.0 ? 312.0 : availableWidth - padding;
+
+    if (availableWidth > 523.0) {
+      width = 312.0;
+    } else if (availableWidth > 240.0) {
+      width = 240.0;
+    } else {
+      width = availableWidth * 0.7;
+    }
+
+    return BoxConstraints(
+      minWidth: width,
+      maxWidth: width,
+      minHeight: 0,
+      maxHeight: availableSize.height * 0.8,
+    );
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final alphaAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: const Interval(0.0, 100.0 / 300.0, curve: Curves.linear),
+      reverseCurve: const Interval(100.0 / 250.0, 1.0, curve: Curves.linear),
+    ));
+
+    final slideAnimation = Tween<Offset>(
+      begin: Offset(alignment.x, alignment.y),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeInOutCubic,
+    ));
+
+    final scaleAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeInOutCubic,
+    ));
+
+    return FadeTransition(
+      opacity: alphaAnimation,
+      child: SlideTransition(
+        position: slideAnimation,
+        child: ScaleTransition(
+          scale: scaleAnimation,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
@@ -3,10 +3,41 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
+/// A [WoltModalType] that displays a floating bottom sheet which is dynamically positioned
+/// relative to an anchor widget identified by [anchorKey]. This modal type allows for a
+/// customizable presentation of content in relation to a specific UI element, enhancing
+/// contextual awareness for the user.
+///
+/// ## Usage
+/// This modal type is designed to be used when there is a need to display information or
+/// actions related to a specific element on the screen. For example, it can be used to
+/// show detailed information about an item in a list or to present actions related to
+/// a specific UI component.
+///
+/// ## Positioning
+/// The modal is positioned based on the location and size of the anchor widget. The
+/// [alignment] parameter determines the modal's position relative to the anchor. If the
+/// anchor widget cannot be found (e.g., if the key is not applied to any existing widget),
+/// the modal will be centered on the screen.
+///
+/// The modal automatically adjusts its size and position to ensure it fits within the
+/// available screen space while respecting the specified alignment relative to the anchor
+/// widget. This behavior ensures that the modal remains accessible and visually connected
+/// to the context it relates to.
+///
+/// ## Considerations
+/// - The [anchorKey] must be applied to a widget that is already in the widget tree for the
+///   modal to position itself correctly.
 class AttachedFloatingBottomSheetType extends WoltModalType {
   static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
   static const Duration _defaultExitDuration = Duration(milliseconds: 300);
 
+  /// Creates an AttachedFloatingBottomSheetType
+  ///
+  /// [anchorKey] is the key of the widget that the bottom sheet will be attached to. Apply this key to the Widget where the Sheet should be attached to
+  /// [alignment] is the alignment of the bottom sheet to the anchor. Default is [Alignment.center]
+  ///
+  /// If the anchor is not found, the bottom sheet will be centered on the screen
   AttachedFloatingBottomSheetType({
     required GlobalKey anchorKey,
     this.alignment = Alignment.center,

--- a/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
@@ -26,6 +26,8 @@ import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 /// ## Considerations
 /// - The [anchorKey] must be applied to a widget that is already in the widget tree for the
 ///   modal to position itself correctly.
+///
+/// Created by ABausG (https://github.com/abausg)
 class AttachedFloatingBottomSheetType extends WoltModalType {
   static const Duration _defaultEnterDuration = Duration(milliseconds: 350);
   static const Duration _defaultExitDuration = Duration(milliseconds: 300);

--- a/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
@@ -99,7 +99,7 @@ class AttachedFloatingBottomSheetType extends WoltModalType {
 
   @override
   BoxConstraints layoutModal(Size availableSize) {
-    const padding = 32.0;
+    const padding = 4.0;
 
     // Calculate Available Space based on Anchor Position
     final double availableWidth;
@@ -158,16 +158,7 @@ class AttachedFloatingBottomSheetType extends WoltModalType {
       }
     }
 
-    double width = availableWidth > 523.0 ? 312.0 : availableWidth - padding;
-
-    if (availableWidth > 312) {
-      width = 312.0;
-    } else if (availableWidth > 240.0) {
-      width = 240.0;
-    } else {
-      width = availableWidth * 0.7;
-    }
-
+    final width = min(availableWidth - padding, 312.0);
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,

--- a/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
+++ b/playground/lib/home/custom_sheets/attached_floating_bottom_sheet_type.dart
@@ -33,7 +33,12 @@ class AttachedFloatingBottomSheetType extends WoltModalType {
   Offset positionModal(
       Size availableSize, Size modalContentSize, TextDirection textDirection) {
     final anchorPosition = _anchorPosition;
-    if (anchorPosition == null) {
+    final isOffscreen = anchorPosition == null ||
+        anchorPosition.dx < 0 ||
+        anchorPosition.dx > availableSize.width ||
+        anchorPosition.dy < 0 ||
+        anchorPosition.dy > availableSize.height;
+    if (isOffscreen) {
       // Return the Center Offset by the size of the modal content
       // If no position found
       return availableSize.center(Offset.zero) -

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -1,8 +1,10 @@
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:playground/home/custom_sheets/attached_floating_bottom_sheet_type.dart';
 import 'package:playground/home/custom_sheets/floating_bottom_sheet_type.dart';
 import 'package:playground/home/custom_sheets/top_notification_sheet_type.dart';
+import 'package:playground/home/pages/custom_sheet_pages/adjust_time_notification_page.dart';
 import 'package:playground/home/pages/custom_sheet_pages/new_order_notification_page.dart';
 import 'package:playground/home/pages/root_sheet_page.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
@@ -30,11 +32,28 @@ class _HomeScreenState extends State<HomeScreen> {
   _Responsiveness _selectedResponsiveness = _Responsiveness.auto;
   TextDirection _selectedDirection = TextDirection.ltr;
 
+  final GlobalKey _attachedAppBarKey = GlobalKey();
+  final GlobalKey _attachedRandomKey = GlobalKey();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
           title: const Text('Wolt Modal Sheet Playground'),
+          leading: IconButton(
+            key: _attachedAppBarKey,
+            icon: const Icon(Icons.anchor),
+            onPressed: () {
+              WoltModalSheet.show(
+                context: context,
+                modalTypeBuilder: (_) => AttachedFloatingBottomSheetType(
+                  anchorKey: _attachedAppBarKey,
+                  alignment: Alignment.topLeft,
+                ),
+                pageListBuilder: (_) => [AdjustTimeNotificationPage()],
+              );
+            },
+          ),
           actions: [
             WoltCircularElevatedButton(
               onPressed: () {
@@ -110,6 +129,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
+                        const Expanded(child: SizedBox.shrink()),
                         const Text('LTR'),
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -125,6 +145,25 @@ class _HomeScreenState extends State<HomeScreen> {
                           ),
                         ),
                         const Text('RTL'),
+                        Expanded(
+                            child: Center(
+                          child: IconButton(
+                            key: _attachedRandomKey,
+                            icon: const Icon(Icons.anchor),
+                            onPressed: () {
+                              WoltModalSheet.show(
+                                context: context,
+                                modalTypeBuilder: (_) =>
+                                    AttachedFloatingBottomSheetType(
+                                  anchorKey: _attachedRandomKey,
+                                  alignment: Alignment.bottomCenter,
+                                ),
+                                pageListBuilder: (_) =>
+                                    [AdjustTimeNotificationPage()],
+                              );
+                            },
+                          ),
+                        ))
                       ],
                     ),
                     const SizedBox(height: 16),

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -48,7 +48,9 @@ class _HomeScreenState extends State<HomeScreen> {
                 context: context,
                 modalTypeBuilder: (_) => AttachedFloatingBottomSheetType(
                   anchorKey: _attachedAppBarKey,
-                  alignment: Alignment.topLeft,
+                  alignment: Directionality.of(context) == TextDirection.ltr
+                      ? Alignment.topLeft
+                      : Alignment.topRight,
                 ),
                 pageListBuilder: (_) => [NewOrderNotificationPage()],
               );

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -50,7 +50,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   anchorKey: _attachedAppBarKey,
                   alignment: Alignment.topLeft,
                 ),
-                pageListBuilder: (_) => [AdjustTimeNotificationPage()],
+                pageListBuilder: (_) => [NewOrderNotificationPage()],
               );
             },
           ),
@@ -159,7 +159,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                   alignment: Alignment.bottomCenter,
                                 ),
                                 pageListBuilder: (_) =>
-                                    [AdjustTimeNotificationPage()],
+                                    [NewOrderNotificationPage()],
                               );
                             },
                           ),

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:playground/home/custom_sheets/attached_floating_bottom_sheet_type.dart';
 import 'package:playground/home/custom_sheets/floating_bottom_sheet_type.dart';
 import 'package:playground/home/custom_sheets/top_notification_sheet_type.dart';
-import 'package:playground/home/pages/custom_sheet_pages/adjust_time_notification_page.dart';
 import 'package:playground/home/pages/custom_sheet_pages/new_order_notification_page.dart';
 import 'package:playground/home/pages/root_sheet_page.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
@@ -48,9 +47,6 @@ class _HomeScreenState extends State<HomeScreen> {
                 context: context,
                 modalTypeBuilder: (_) => AttachedFloatingBottomSheetType(
                   anchorKey: _attachedAppBarKey,
-                  alignment: Directionality.of(context) == TextDirection.ltr
-                      ? Alignment.topLeft
-                      : Alignment.topRight,
                 ),
                 pageListBuilder: (_) => [NewOrderNotificationPage()],
               );
@@ -158,7 +154,6 @@ class _HomeScreenState extends State<HomeScreen> {
                                 modalTypeBuilder: (_) =>
                                     AttachedFloatingBottomSheetType(
                                   anchorKey: _attachedRandomKey,
-                                  alignment: Alignment.bottomCenter,
                                 ),
                                 pageListBuilder: (_) =>
                                     [NewOrderNotificationPage()],


### PR DESCRIPTION
## Description

Adding an AttachedFloatingBottomSheetType to the Playground App.
This works by using a `GlobalKey` as the anchor to Align the Sheet at the Position of the Anchor.

One thing I think can still be improved is the animation. Ideally it would be nice if the Modal Scales out from the anchor position (+ Transformation based on Anchor Size/Alignment)

A Demo (before improvements to the Alignments/Size Constraints can be found here:

https://github.com/user-attachments/assets/9b1f6b7c-4a64-46c8-9eae-91cce0d5893d



## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

