### PR TITLE
[Breaking Change] Introduce modal and page content decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ for page transitions, and scrollable content within each page.
 - [Modal Types](#modal-types)
   * [Defining Custom Modal Types](#defining-custom-modal-types)
   * [Modal Type Responsiveness](#modal-type-responsiveness)
-  * [Migration from v0.6.0 to v0.7.0](#migration-from-v060-to-v070)
+- [Decorating modal types, modal, and pages](#decorating-modal-types-modal-and-pages)
+  * [Decoration Approaches](#decoration-approaches)
+    + [Modal Type Level Decoration](#modal-type-level-decoration)
+    + [Modal Level Decoration](#modal-level-decoration)
+  * [Types of Decoration](#types-of-decoration)
+    + [Page Content Decoration](#page-content-decoration)
+    + [Modal Decoration](#modal-decoration)
+      - [Why use modalDecorator for state management?](#why-use-modaldecorator-for-state-management)
+  * [Migration to v0.8.0](#migration-to-v080)
 - [Usage of WoltModalSheet Pages](#usage-of-woltmodalsheet-pages)
   * [SliverWoltModalSheetPage](#sliverwoltmodalsheetpage)
   * [WoltModalSheetPage](#woltmodalsheetpage)
@@ -334,15 +342,115 @@ dynamical screen width:
 
 ![Responsive modals](https://github.com/woltapp/wolt_modal_sheet/blob/main/doc/ss_type_builder.gif?raw=true)
 
-### Migration from v0.6.0 to v0.7.0
+## Decorating modal types, modal, and pages
+WoltModalSheet uses the decorator pattern, which is a structural design 
+pattern allowing dynamic addition of behavior to individual objects. In 
+Flutter, this is typically achieved by wrapping widgets with other widgets, 
+enhancing or modifying their behavior.
 
-- WoltModalType.bottomSheet is now WoltModalType.bottomSheet()
-- WoltModalType.dialog is now WoltModalType.dialog()
-- The `transitionDuration`, `bottomSheetTransitionAnimation`, 
-  `dialogTransitionAnimation`,`minDialogWidth`,`maxDialogWidth`, 
-  `minPageHeight`,`maxPageHeight` are removed from `WoltModalSheet.show()`. 
-  These values can be set in `WoltBottomSheetType`, `WoltDialogType` or a 
-  custom modal type instead.
+### Decoration Approaches
+
+Decoration can be achieved at both the modal type level and the modal level.
+
+#### Modal Type Level Decoration
+
+The modal type level decoration is applied to all modals of the same type. 
+To decorate at the modal type level, you extend the corresponding 
+`WoltModalType` class and override the related methods.
+
+Example:
+
+```dart
+class MyCustomBottomSheetType extends WoltBottomSheetType {
+  const MyCustomBottomSheetType() : super();
+
+  @override
+  Widget decoratePageContent(BuildContext context, Widget child, bool useSafeArea) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: child,
+    );
+  }
+
+  @override
+  Widget decorateModal(BuildContext context, Widget modal, bool useSafeArea) {
+    return useSafeArea ? SafeArea(child: modal) : modal;
+  }
+}
+```
+
+#### Modal Level Decoration
+
+Decoration at the modal level is applied when using the modal and can be 
+applied to all modal types when the modal sheet is visible. This is done 
+through the `pageContentDecorator` and `modalDecorator`.
+
+Example:
+
+```dart
+WoltModalSheet.show(
+  context: context,
+  pageContentDecorator: (widget) => Align(
+      alignment: Alignment.bottomCenter,
+      child: ClipRRect(
+        ..., // Your clipRRect properties
+        child: BackdropFilter(
+          ..., // Your backdrop filter properties
+          child: widget,
+        ),
+    ),
+  ),
+  modalDecorator: (child) {
+    // Wrap the modal with `ChangeNotifierProvider` to manage the state of 
+    // the entire pages.
+    return ChangeNotifierProvider<StoreOnlineViewModel>.value(
+      value: viewModel,
+      builder: (_, __) => child,
+    );
+  },
+  pageListBuilder: (context) => [
+    // Your pages here
+  ],
+);
+```
+
+### Types of Decoration
+
+#### Page Content Decoration
+
+- Purpose: Applies additional decorations to the modal page content only, 
+  excluding the barrier.
+- Usage: Useful for modifying or enhancing the appearance and behavior of 
+  the modal content without affecting the surrounding barrier.
+
+```dart
+Widget Function(Widget)? pageContentDecorator;
+```
+
+#### Modal Decoration
+
+- Purpose: Applies additional decorations to the entire modal, including the 
+  barrier and the page content.
+- Usage: Useful for wrapping the entire modal with a widget that manages the 
+  state of the entire pages.
+
+```dart
+Widget Function(Widget)? modalDecorator;
+```
+
+##### Why use modalDecorator for state management?
+
+When managing the state across the entire modal, such as providing a
+ChangeNotifierProvider for state management, it is important to wrap the
+entire modal rather than just the page content. This ensures that the state
+is accessible throughout the entire modal lifecycle and all its components.
+
+### Migration to v0.8.0
+
+Versions before the v0.6.0 release used the `decorator` field to decorate as 
+`modalDecorator`. In release v0.6.0 and later, the `decorator` field was 
+used as `pageContentDecorator`. In v0.8.0, the `decorator` field was removed 
+and replaced with `pageContentDecorator` and `modalDecorator`.
 
 ## Usage of WoltModalSheet Pages
 

--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ current state:
 
     WoltModalSheet.show(
       context: context,
-      decorator: (child) {
+      pageContentDecorator: (child) {
         return ChangeNotifierProvider<StoreOnlineViewModel>.value(
           value: model,
           builder: (_, __) => child,

--- a/coffee_maker/lib/home/online/modal_pages/add_water/add_water_description_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/add_water/add_water_description_modal_page.dart
@@ -1,13 +1,14 @@
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class AddWaterDescriptionModalPage {
   AddWaterDescriptionModalPage._();
 
-  static WoltModalSheetPage build(String coffeeOrderId) {
+  static WoltModalSheetPage build(
+    String coffeeOrderId, {
+    required VoidCallback onCancelOrder,
+  }) {
     return WoltModalSheetPage(
       heroImage: const Image(
         image: AssetImage('lib/assets/images/add_water_description.png'),
@@ -18,13 +19,8 @@ class AddWaterDescriptionModalPage {
         child: Column(
           children: [
             Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
-
               return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(coffeeOrderId);
-                  Navigator.pop(context);
-                },
+                onPressed: onCancelOrder,
                 theme: WoltElevatedButtonTheme.secondary,
                 child: const Text('Cancel order'),
               );

--- a/coffee_maker/lib/home/online/modal_pages/add_water/water_settings_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/add_water/water_settings_modal_page.dart
@@ -1,16 +1,16 @@
-import 'package:coffee_maker/entities/coffee_maker_step.dart';
 import 'package:coffee_maker/home/online/modal_pages/add_water/widgets/water_quantity_temperature_input.dart';
 import 'package:coffee_maker/home/online/modal_pages/add_water/widgets/water_source_list.dart';
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class WaterSettingsModalPage {
   WaterSettingsModalPage._();
 
-  static WoltModalSheetPage build(String coffeeOrderId) {
+  static WoltModalSheetPage build(
+    String coffeeOrderId, {
+    required VoidCallback onFinishAddingWater,
+  }) {
     final buttonEnabledListener = ValueNotifier(false);
     const pageTitle = 'Water settings';
 
@@ -20,18 +20,11 @@ class WaterSettingsModalPage {
         builder: (_, isEnabled, __) {
           return Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-            child: Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
-              return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(
-                      coffeeOrderId, CoffeeMakerStep.ready);
-                  Navigator.pop(context);
-                },
-                enabled: isEnabled,
-                child: const Text('Finish adding water'),
-              );
-            }),
+            child: WoltElevatedButton(
+              onPressed: onFinishAddingWater,
+              enabled: isEnabled,
+              child: const Text('Finish adding water'),
+            ),
           );
         },
       ),

--- a/coffee_maker/lib/home/online/modal_pages/grind/grind_or_reject_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/grind/grind_or_reject_modal_page.dart
@@ -1,14 +1,14 @@
-import 'package:coffee_maker/entities/coffee_maker_step.dart';
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class GrindOrRejectModalPage {
   GrindOrRejectModalPage._();
 
-  static WoltModalSheetPage build({required String coffeeOrderId}) {
+  static WoltModalSheetPage build({
+    required String coffeeOrderId,
+    required VoidCallback onGrindCoffeeTapped,
+  }) {
     return WoltModalSheetPage(
       stickyActionBar: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
@@ -23,17 +23,10 @@ class GrindOrRejectModalPage {
               );
             }),
             const SizedBox(height: 8),
-            Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
-              return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(
-                      coffeeOrderId, CoffeeMakerStep.addWater);
-                  Navigator.pop(context);
-                },
-                child: const Text('Start grinding'),
-              );
-            }),
+            WoltElevatedButton(
+              onPressed: onGrindCoffeeTapped,
+              child: const Text('Start grinding'),
+            ),
           ],
         ),
       ),

--- a/coffee_maker/lib/home/online/modal_pages/grind/reject_order_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/grind/reject_order_modal_page.dart
@@ -1,14 +1,15 @@
 import 'package:coffee_maker/home/online/modal_pages/grind/reject_order_reason.dart';
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class RejectOrderModalPage {
   RejectOrderModalPage._();
 
-  static WoltModalSheetPage build({required String coffeeOrderId}) {
+  static WoltModalSheetPage build({
+    required String coffeeOrderId,
+    required VoidCallback onRejectOrderTapped,
+  }) {
     final buttonEnabledListener = ValueNotifier(false);
 
     return WoltModalSheetPage(
@@ -18,12 +19,8 @@ class RejectOrderModalPage {
           return Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
             child: Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
               return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(coffeeOrderId);
-                  Navigator.pop(context);
-                },
+                onPressed: onRejectOrderTapped,
                 theme: WoltElevatedButtonTheme.secondary,
                 colorName: WoltColorName.red,
                 enabled: isEnabled,

--- a/coffee_maker/lib/home/online/modal_pages/ready/offer_recommendation_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/ready/offer_recommendation_modal_page.dart
@@ -1,15 +1,16 @@
 import 'package:coffee_maker/home/online/modal_pages/ready/extra_recommendation.dart';
 import 'package:coffee_maker/home/online/modal_pages/ready/extra_recommendation_tile.dart';
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class OfferRecommendationModalPage {
   OfferRecommendationModalPage._();
 
-  static SliverWoltModalSheetPage build({required String coffeeOrderId}) {
+  static SliverWoltModalSheetPage build({
+    required String coffeeOrderId,
+    required VoidCallback onServeWithRecommendation,
+  }) {
     final selectedItemCountListener = ValueNotifier(0);
     const pageTitle = 'Recommendations';
     const allRecommendations = ExtraRecommendation.values;
@@ -30,17 +31,11 @@ class OfferRecommendationModalPage {
           }
           return Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-            child: Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
-              return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(coffeeOrderId);
-                  Navigator.pop(context);
-                },
-                enabled: count > 0,
-                child: Text(buttonText),
-              );
-            }),
+            child: WoltElevatedButton(
+              onPressed: onServeWithRecommendation,
+              enabled: count > 0,
+              child: Text(buttonText),
+            ),
           );
         },
       ),

--- a/coffee_maker/lib/home/online/modal_pages/ready/serve_or_offer_modal_page.dart
+++ b/coffee_maker/lib/home/online/modal_pages/ready/serve_or_offer_modal_page.dart
@@ -1,13 +1,14 @@
-import 'package:coffee_maker/home/online/view_model/store_online_view_model.dart';
 import 'package:demo_ui_components/demo_ui_components.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 class ServeOrOfferModalPage {
   ServeOrOfferModalPage._();
 
-  static WoltModalSheetPage build({required String coffeeOrderId}) {
+  static WoltModalSheetPage build({
+    required String coffeeOrderId,
+    required VoidCallback onServeCoffeeTapped,
+  }) {
     return WoltModalSheetPage(
       heroImage: const Image(
         image: AssetImage('lib/assets/images/coffee_is_ready.png'),
@@ -17,17 +18,11 @@ class ServeOrOfferModalPage {
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         child: Column(
           children: [
-            Builder(builder: (context) {
-              final model = context.read<StoreOnlineViewModel>();
-              return WoltElevatedButton(
-                onPressed: () {
-                  model.onCoffeeOrderStatusChange(coffeeOrderId);
-                  Navigator.pop(context);
-                },
-                theme: WoltElevatedButtonTheme.secondary,
-                child: const Text('Serve coffee'),
-              );
-            }),
+            WoltElevatedButton(
+              onPressed: onServeCoffeeTapped,
+              theme: WoltElevatedButtonTheme.secondary,
+              child: const Text('Serve coffee'),
+            ),
             const SizedBox(height: 8),
             Builder(builder: (context) {
               return WoltElevatedButton(

--- a/coffee_maker/lib/home/online/store_online_content.dart
+++ b/coffee_maker/lib/home/online/store_online_content.dart
@@ -93,17 +93,30 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
 
   void _onCoffeeOrderSelectedInGrindState(
       BuildContext context, String coffeeOrderId) {
-    final model = context.read<StoreOnlineViewModel>();
+    final viewModel = context.read<StoreOnlineViewModel>();
 
     WoltModalSheet.show(
       context: context,
       pageListBuilder: (context) => [
-        GrindOrRejectModalPage.build(coffeeOrderId: coffeeOrderId),
-        RejectOrderModalPage.build(coffeeOrderId: coffeeOrderId),
+        GrindOrRejectModalPage.build(
+          coffeeOrderId: coffeeOrderId,
+          onGrindCoffeeTapped: () {
+            viewModel.onCoffeeOrderStatusChange(
+                coffeeOrderId, CoffeeMakerStep.addWater);
+            Navigator.pop(context);
+          },
+        ),
+        RejectOrderModalPage.build(
+          coffeeOrderId: coffeeOrderId,
+          onRejectOrderTapped: () {
+            viewModel.onCoffeeOrderStatusChange(coffeeOrderId);
+            Navigator.pop(context);
+          },
+        ),
       ],
-      decorator: (child) {
+      modalDecorator: (child) {
         return ChangeNotifierProvider<StoreOnlineViewModel>.value(
-          value: model,
+          value: viewModel,
           builder: (_, __) => child,
         );
       },
@@ -113,20 +126,33 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
 
   void _onCoffeeOrderSelectedInAddWaterState(
       BuildContext context, String coffeeOrderId) {
-    final model = context.read<StoreOnlineViewModel>();
+    final viewModel = context.read<StoreOnlineViewModel>();
 
     WoltModalSheet.show(
       context: context,
-      decorator: (child) {
+      modalDecorator: (child) {
         return ChangeNotifierProvider<StoreOnlineViewModel>.value(
-          value: model,
+          value: viewModel,
           builder: (_, __) => child,
         );
       },
       pageListBuilder: (context) {
         return [
-          AddWaterDescriptionModalPage.build(coffeeOrderId),
-          WaterSettingsModalPage.build(coffeeOrderId)
+          AddWaterDescriptionModalPage.build(
+            coffeeOrderId,
+            onCancelOrder: () {
+              viewModel.onCoffeeOrderStatusChange(coffeeOrderId);
+              Navigator.pop(context);
+            },
+          ),
+          WaterSettingsModalPage.build(
+            coffeeOrderId,
+            onFinishAddingWater: () {
+              viewModel.onCoffeeOrderStatusChange(
+                  coffeeOrderId, CoffeeMakerStep.ready);
+              Navigator.pop(context);
+            },
+          ),
         ];
       },
       modalTypeBuilder: _modalTypeBuilder,
@@ -135,17 +161,30 @@ class _StoreOnlineContentState extends State<StoreOnlineContent> {
 
   void _onCoffeeOrderSelectedInReadyState(
       BuildContext context, String coffeeOrderId) {
-    final model = context.read<StoreOnlineViewModel>();
+    final viewModel = context.read<StoreOnlineViewModel>();
 
     WoltModalSheet.show(
       context: context,
-      pageListBuilder: (context) => [
-        ServeOrOfferModalPage.build(coffeeOrderId: coffeeOrderId),
-        OfferRecommendationModalPage.build(coffeeOrderId: coffeeOrderId)
-      ],
-      decorator: (child) {
+      pageListBuilder: (context) {
+        return [
+          ServeOrOfferModalPage.build(
+            coffeeOrderId: coffeeOrderId,
+            onServeCoffeeTapped: () {
+              viewModel.onCoffeeOrderStatusChange(coffeeOrderId);
+              Navigator.pop(context);
+            },
+          ),
+          OfferRecommendationModalPage.build(
+              coffeeOrderId: coffeeOrderId,
+              onServeWithRecommendation: () {
+                viewModel.onCoffeeOrderStatusChange(coffeeOrderId);
+                Navigator.pop(context);
+              }),
+        ];
+      },
+      modalDecorator: (child) {
         return ChangeNotifierProvider<StoreOnlineViewModel>.value(
-          value: model,
+          value: viewModel,
           builder: (_, __) => child,
         );
       },

--- a/coffee_maker_navigator_2/lib/ui/orders/view/widgets/coffee_order_list_view_for_step.dart
+++ b/coffee_maker_navigator_2/lib/ui/orders/view/widgets/coffee_order_list_view_for_step.dart
@@ -78,7 +78,7 @@ void _onCoffeeOrderSelectedInReadyState(
       ServeOrOfferModalPage.build(coffeeOrderId: coffeeOrderId),
       OfferRecommendationModalPage.build(coffeeOrderId: coffeeOrderId)
     ],
-    decorator: (child) {
+    pageContentDecorator: (child) {
       return ChangeNotifierProvider<OrdersScreenViewModel>.value(
         value: model,
         builder: (_, __) => child,

--- a/lib/src/modal_type/wolt_modal_type.dart
+++ b/lib/src/modal_type/wolt_modal_type.dart
@@ -125,7 +125,7 @@ abstract class WoltModalType {
     Widget child,
   );
 
-  /// Applies additional decorations to the modal pqge content.
+  /// Applies additional decorations to the modal page content.
   ///
   /// This method can be overridden to provide custom decorations such as safe area padding
   /// adjustments inside the modal page content. By default, it does not apply any decoration.

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -24,7 +24,8 @@ class WoltModalSheet<T> extends StatefulWidget {
     required this.pageIndexNotifier,
     required this.onModalDismissedWithBarrierTap,
     required this.onModalDismissedWithDrag,
-    required this.decorator,
+    required this.pageContentDecorator,
+    required this.modalDecorator,
     required this.modalTypeBuilder,
     required this.transitionAnimationController,
     required this.route,
@@ -54,9 +55,13 @@ class WoltModalSheet<T> extends StatefulWidget {
   /// Navigator 2.0).
   final VoidCallback? onModalDismissedWithDrag;
 
-  /// A function that takes a widget and returns a decorated version of that widget. This can be
-  /// used to handle the state management of the modal from top level in the modal route.
-  final Widget Function(Widget)? decorator;
+  /// A function that takes the modal page content and returns a decorated version of it. The
+  /// decoration is not applied to the barrier. Use [modalDecorator] to apply decorations to the
+  /// barrier and the content.
+  final Widget Function(Widget)? pageContentDecorator;
+
+  /// Applies additional decorations to the modal including the barrier and the content.
+  final Widget Function(Widget)? modalDecorator;
 
   /// A builder function that determines the [WoltModalType] based on the provided BuildContext.
   /// This allows responsive design to switch between modal types as the screen size changes. For
@@ -104,7 +109,8 @@ class WoltModalSheet<T> extends StatefulWidget {
   ///   visible page. If not provided, a new [ValueNotifier] will be created with the 0th index.
   ///   If you want to handle in-modal navigation without considering page index, you can ignore
   ///   providing this notifier.
-  ///   - `decorator`: Optional widget function to decorate the modal content.
+  ///   - `pageContentDecorator`: Applies additional decorations to the page content.
+  ///   - `modalDecorator`: Applies additional decorations to the modal.
   ///   - `useRootNavigator`: Whether to use the root navigator for navigation.
   ///   - `useSafeArea`: Whether the modal should respect the safe area.
   ///   - `barrierDismissible`: Whether the modal can be dismissed by tapping the barrier.
@@ -124,7 +130,8 @@ class WoltModalSheet<T> extends StatefulWidget {
     required WoltModalSheetPageListBuilder pageListBuilder,
     WoltModalTypeBuilder? modalTypeBuilder,
     ValueNotifier<int>? pageIndexNotifier,
-    Widget Function(Widget)? decorator,
+    Widget Function(Widget)? pageContentDecorator,
+    Widget Function(Widget)? modalDecorator,
     bool useRootNavigator = false,
     bool? useSafeArea,
     bool? barrierDismissible,
@@ -142,7 +149,8 @@ class WoltModalSheet<T> extends StatefulWidget {
       pageListBuilderNotifier: ValueNotifier(pageListBuilder),
       modalTypeBuilder: modalTypeBuilder,
       pageIndexNotifier: pageIndexNotifier,
-      decorator: decorator,
+      pageContentDecorator: pageContentDecorator,
+      modalDecorator: modalDecorator,
       useRootNavigator: useRootNavigator,
       useSafeArea: useSafeArea,
       barrierDismissible: barrierDismissible,
@@ -170,7 +178,8 @@ class WoltModalSheet<T> extends StatefulWidget {
   ///   - `pageListBuilderNotifier`: Notifier for dynamically updating the list of pages.
   ///   - `modalTypeBuilder`: Optional builder for setting the modal type based on context.
   ///   - `pageIndexNotifier`: Notifier for tracking and updating the index of the currently visible page.
-  ///   - `decorator`: Optional widget function to decorate the modal content.
+  ///   - `pageContentDecorator`: Applies additional decorations to the page content.
+  ///   - `modalDecorator`: Applies additional decorations to the modal content.
   ///   - `useRootNavigator`: Whether to use the root navigator for navigation.
   ///   - `useSafeArea`: Whether the modal should respect the safe area.
   ///   - `barrierDismissible`: Whether the modal can be dismissed by tapping the barrier.
@@ -191,7 +200,8 @@ class WoltModalSheet<T> extends StatefulWidget {
         pageListBuilderNotifier,
     WoltModalTypeBuilder? modalTypeBuilder,
     ValueNotifier<int>? pageIndexNotifier,
-    Widget Function(Widget)? decorator,
+    Widget Function(Widget)? pageContentDecorator,
+    Widget Function(Widget)? modalDecorator,
     bool useRootNavigator = false,
     bool? useSafeArea,
     bool? barrierDismissible,
@@ -208,7 +218,8 @@ class WoltModalSheet<T> extends StatefulWidget {
         Navigator.of(context, rootNavigator: useRootNavigator);
     return navigator.push<T>(
       WoltModalSheetRoute<T>(
-        decorator: decorator,
+        pageContentDecorator: pageContentDecorator,
+        modalDecorator: modalDecorator,
         pageIndexNotifier: pageIndexNotifier ?? ValueNotifier(0),
         pageListBuilderNotifier: pageListBuilderNotifier,
         modalTypeBuilder: modalTypeBuilder,
@@ -264,8 +275,12 @@ class WoltModalSheet<T> extends StatefulWidget {
 class WoltModalSheetState extends State<WoltModalSheet> {
   List<SliverWoltModalSheetPage> _pages = [];
 
-  Widget Function(Widget) get _decorator =>
-      widget.decorator ?? (widget) => Builder(builder: (_) => widget);
+  Widget Function(Widget) get _pageContentDecorator =>
+      widget.pageContentDecorator ??
+      (widget) => Builder(builder: (_) => widget);
+
+  Widget Function(Widget) get _modalDecorator =>
+      widget.modalDecorator ?? (widget) => Builder(builder: (_) => widget);
 
   final GlobalKey _childKey = GlobalKey(debugLabel: 'Modal sheet child');
 
@@ -312,110 +327,114 @@ class WoltModalSheetState extends State<WoltModalSheet> {
     final modalType =
         WoltModalTypeUtils.currentModalType(widget.modalTypeBuilder, context);
 
-    return ValueListenableBuilder(
-      valueListenable: widget.pageIndexNotifier,
-      builder: (context, currentPageIndex, __) {
-        final pages = _pages;
-        final page = pages[currentPageIndex];
-        final enableDrag = page.enableDrag ??
-            widget.enableDrag ??
-            modalType.isDragToDismissEnabled ??
-            themeData?.enableDrag ??
-            defaultThemeData.enableDrag;
-        final showDragHandle = widget.showDragHandle ??
-            modalType.showDragHandle ??
-            (enableDrag &&
-                (themeData?.showDragHandle ?? defaultThemeData.showDragHandle));
-        final shadowColor =
-            themeData?.shadowColor ?? defaultThemeData.shadowColor;
-        final pageBackgroundColor = page.backgroundColor ??
-            themeData?.backgroundColor ??
-            defaultThemeData.backgroundColor;
-        final surfaceTintColor = page.surfaceTintColor ??
-            themeData?.surfaceTintColor ??
-            defaultThemeData.surfaceTintColor;
-        final modalElevation =
-            themeData?.modalElevation ?? defaultThemeData.modalElevation;
-        final clipBehavior =
-            themeData?.clipBehavior ?? defaultThemeData.clipBehavior;
-        final resizeToAvoidBottomInset = page.resizeToAvoidBottomInset ??
-            themeData?.resizeToAvoidBottomInset ??
-            defaultThemeData.resizeToAvoidBottomInset;
-        final useSafeArea = page.useSafeArea ??
-            widget.useSafeArea ??
-            themeData?.useSafeArea ??
-            defaultThemeData.useSafeArea;
+    return _modalDecorator(
+      ValueListenableBuilder(
+        valueListenable: widget.pageIndexNotifier,
+        builder: (context, currentPageIndex, __) {
+          final pages = _pages;
+          final page = pages[currentPageIndex];
+          final enableDrag = page.enableDrag ??
+              widget.enableDrag ??
+              modalType.isDragToDismissEnabled ??
+              themeData?.enableDrag ??
+              defaultThemeData.enableDrag;
+          final showDragHandle = widget.showDragHandle ??
+              modalType.showDragHandle ??
+              (enableDrag &&
+                  (themeData?.showDragHandle ??
+                      defaultThemeData.showDragHandle));
+          final shadowColor =
+              themeData?.shadowColor ?? defaultThemeData.shadowColor;
+          final pageBackgroundColor = page.backgroundColor ??
+              themeData?.backgroundColor ??
+              defaultThemeData.backgroundColor;
+          final surfaceTintColor = page.surfaceTintColor ??
+              themeData?.surfaceTintColor ??
+              defaultThemeData.surfaceTintColor;
+          final modalElevation =
+              themeData?.modalElevation ?? defaultThemeData.modalElevation;
+          final clipBehavior =
+              themeData?.clipBehavior ?? defaultThemeData.clipBehavior;
+          final resizeToAvoidBottomInset = page.resizeToAvoidBottomInset ??
+              themeData?.resizeToAvoidBottomInset ??
+              defaultThemeData.resizeToAvoidBottomInset;
+          final useSafeArea = page.useSafeArea ??
+              widget.useSafeArea ??
+              themeData?.useSafeArea ??
+              defaultThemeData.useSafeArea;
 
-        final multiChildLayout = CustomMultiChildLayout(
-          delegate: _WoltModalMultiChildLayoutDelegate(
-            contentLayoutId: contentLayoutId,
-            barrierLayoutId: barrierLayoutId,
-            modalType: modalType,
-            textDirection: Directionality.of(context),
-          ),
-          children: [
-            LayoutId(
-              id: barrierLayoutId,
-              child: WoltAnimatedModalBarrier(
-                animationController: widget.route.animationController!,
-                barrierDismissible: widget.route.barrierDismissible,
-                onModalDismissedWithBarrierTap:
-                    widget.onModalDismissedWithBarrierTap,
-              ),
+          final multiChildLayout = CustomMultiChildLayout(
+            delegate: _WoltModalMultiChildLayoutDelegate(
+              contentLayoutId: contentLayoutId,
+              barrierLayoutId: barrierLayoutId,
+              modalType: modalType,
+              textDirection: Directionality.of(context),
             ),
-            LayoutId(
-              id: contentLayoutId,
-              child: _decorator(
-                KeyedSubtree(
-                  key: _childKey,
-                  child: Semantics(
-                    label: modalType.routeLabel(context),
-                    child: WoltModalSheetContentGestureDetector(
-                      route: widget.route,
-                      enableDrag: enableDrag,
-                      modalContentKey: _childKey,
-                      onModalDismissedWithDrag: widget.onModalDismissedWithDrag,
-                      modalType: modalType,
-                      child: Material(
-                        color: pageBackgroundColor,
-                        elevation: modalElevation,
-                        surfaceTintColor: surfaceTintColor,
-                        shadowColor: shadowColor,
-                        shape: modalType.shapeBorder,
-                        clipBehavior: clipBehavior,
-                        child: LayoutBuilder(
-                          builder: (_, constraints) {
-                            return modalType.decoratePageContent(
-                              context,
-                              WoltModalSheetAnimatedSwitcher(
-                                woltModalType: modalType,
-                                pageIndex: currentPageIndex,
-                                pages: pages,
-                                sheetWidth: constraints.maxWidth,
-                                showDragHandle: showDragHandle,
-                              ),
-                              useSafeArea,
-                            );
-                          },
+            children: [
+              LayoutId(
+                id: barrierLayoutId,
+                child: WoltAnimatedModalBarrier(
+                  animationController: widget.route.animationController!,
+                  barrierDismissible: widget.route.barrierDismissible,
+                  onModalDismissedWithBarrierTap:
+                      widget.onModalDismissedWithBarrierTap,
+                ),
+              ),
+              LayoutId(
+                id: contentLayoutId,
+                child: _pageContentDecorator(
+                  KeyedSubtree(
+                    key: _childKey,
+                    child: Semantics(
+                      label: modalType.routeLabel(context),
+                      child: WoltModalSheetContentGestureDetector(
+                        route: widget.route,
+                        enableDrag: enableDrag,
+                        modalContentKey: _childKey,
+                        onModalDismissedWithDrag:
+                            widget.onModalDismissedWithDrag,
+                        modalType: modalType,
+                        child: Material(
+                          color: pageBackgroundColor,
+                          elevation: modalElevation,
+                          surfaceTintColor: surfaceTintColor,
+                          shadowColor: shadowColor,
+                          shape: modalType.shapeBorder,
+                          clipBehavior: clipBehavior,
+                          child: LayoutBuilder(
+                            builder: (_, constraints) {
+                              return modalType.decoratePageContent(
+                                context,
+                                WoltModalSheetAnimatedSwitcher(
+                                  woltModalType: modalType,
+                                  pageIndex: currentPageIndex,
+                                  pages: pages,
+                                  sheetWidth: constraints.maxWidth,
+                                  showDragHandle: showDragHandle,
+                                ),
+                                useSafeArea,
+                              );
+                            },
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
               ),
+            ],
+          );
+          return Scaffold(
+            resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+            backgroundColor: Colors.transparent,
+            body: modalType.decorateModal(
+              context,
+              multiChildLayout,
+              useSafeArea,
             ),
-          ],
-        );
-        return Scaffold(
-          resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-          backgroundColor: Colors.transparent,
-          body: modalType.decorateModal(
-            context,
-            multiChildLayout,
-            useSafeArea,
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -275,13 +275,6 @@ class WoltModalSheet<T> extends StatefulWidget {
 class WoltModalSheetState extends State<WoltModalSheet> {
   List<SliverWoltModalSheetPage> _pages = [];
 
-  Widget Function(Widget) get _pageContentDecorator =>
-      widget.pageContentDecorator ??
-      (widget) => Builder(builder: (_) => widget);
-
-  Widget Function(Widget) get _modalDecorator =>
-      widget.modalDecorator ?? (widget) => Builder(builder: (_) => widget);
-
   final GlobalKey _childKey = GlobalKey(debugLabel: 'Modal sheet child');
 
   static const barrierLayoutId = 'barrierLayoutId';
@@ -327,115 +320,119 @@ class WoltModalSheetState extends State<WoltModalSheet> {
     final modalType =
         WoltModalTypeUtils.currentModalType(widget.modalTypeBuilder, context);
 
-    return _modalDecorator(
-      ValueListenableBuilder(
-        valueListenable: widget.pageIndexNotifier,
-        builder: (context, currentPageIndex, __) {
-          final pages = _pages;
-          final page = pages[currentPageIndex];
-          final enableDrag = page.enableDrag ??
-              widget.enableDrag ??
-              modalType.isDragToDismissEnabled ??
-              themeData?.enableDrag ??
-              defaultThemeData.enableDrag;
-          final showDragHandle = widget.showDragHandle ??
-              modalType.showDragHandle ??
-              (enableDrag &&
-                  (themeData?.showDragHandle ??
-                      defaultThemeData.showDragHandle));
-          final shadowColor =
-              themeData?.shadowColor ?? defaultThemeData.shadowColor;
-          final pageBackgroundColor = page.backgroundColor ??
-              themeData?.backgroundColor ??
-              defaultThemeData.backgroundColor;
-          final surfaceTintColor = page.surfaceTintColor ??
-              themeData?.surfaceTintColor ??
-              defaultThemeData.surfaceTintColor;
-          final modalElevation =
-              themeData?.modalElevation ?? defaultThemeData.modalElevation;
-          final clipBehavior =
-              themeData?.clipBehavior ?? defaultThemeData.clipBehavior;
-          final resizeToAvoidBottomInset = page.resizeToAvoidBottomInset ??
-              themeData?.resizeToAvoidBottomInset ??
-              defaultThemeData.resizeToAvoidBottomInset;
-          final useSafeArea = page.useSafeArea ??
-              widget.useSafeArea ??
-              themeData?.useSafeArea ??
-              defaultThemeData.useSafeArea;
+    Widget modalContent = ValueListenableBuilder(
+      valueListenable: widget.pageIndexNotifier,
+      builder: (context, currentPageIndex, __) {
+        final pages = _pages;
+        final page = pages[currentPageIndex];
+        final enableDrag = page.enableDrag ??
+            widget.enableDrag ??
+            modalType.isDragToDismissEnabled ??
+            themeData?.enableDrag ??
+            defaultThemeData.enableDrag;
+        final showDragHandle = widget.showDragHandle ??
+            modalType.showDragHandle ??
+            (enableDrag &&
+                (themeData?.showDragHandle ?? defaultThemeData.showDragHandle));
+        final shadowColor =
+            themeData?.shadowColor ?? defaultThemeData.shadowColor;
+        final pageBackgroundColor = page.backgroundColor ??
+            themeData?.backgroundColor ??
+            defaultThemeData.backgroundColor;
+        final surfaceTintColor = page.surfaceTintColor ??
+            themeData?.surfaceTintColor ??
+            defaultThemeData.surfaceTintColor;
+        final modalElevation =
+            themeData?.modalElevation ?? defaultThemeData.modalElevation;
+        final clipBehavior =
+            themeData?.clipBehavior ?? defaultThemeData.clipBehavior;
+        final resizeToAvoidBottomInset = page.resizeToAvoidBottomInset ??
+            themeData?.resizeToAvoidBottomInset ??
+            defaultThemeData.resizeToAvoidBottomInset;
+        final useSafeArea = page.useSafeArea ??
+            widget.useSafeArea ??
+            themeData?.useSafeArea ??
+            defaultThemeData.useSafeArea;
 
-          final multiChildLayout = CustomMultiChildLayout(
-            delegate: _WoltModalMultiChildLayoutDelegate(
-              contentLayoutId: contentLayoutId,
-              barrierLayoutId: barrierLayoutId,
+        Widget pageContent = KeyedSubtree(
+          key: _childKey,
+          child: Semantics(
+            label: modalType.routeLabel(context),
+            child: WoltModalSheetContentGestureDetector(
+              route: widget.route,
+              enableDrag: enableDrag,
+              modalContentKey: _childKey,
+              onModalDismissedWithDrag: widget.onModalDismissedWithDrag,
               modalType: modalType,
-              textDirection: Directionality.of(context),
-            ),
-            children: [
-              LayoutId(
-                id: barrierLayoutId,
-                child: WoltAnimatedModalBarrier(
-                  animationController: widget.route.animationController!,
-                  barrierDismissible: widget.route.barrierDismissible,
-                  onModalDismissedWithBarrierTap:
-                      widget.onModalDismissedWithBarrierTap,
-                ),
-              ),
-              LayoutId(
-                id: contentLayoutId,
-                child: _pageContentDecorator(
-                  KeyedSubtree(
-                    key: _childKey,
-                    child: Semantics(
-                      label: modalType.routeLabel(context),
-                      child: WoltModalSheetContentGestureDetector(
-                        route: widget.route,
-                        enableDrag: enableDrag,
-                        modalContentKey: _childKey,
-                        onModalDismissedWithDrag:
-                            widget.onModalDismissedWithDrag,
-                        modalType: modalType,
-                        child: Material(
-                          color: pageBackgroundColor,
-                          elevation: modalElevation,
-                          surfaceTintColor: surfaceTintColor,
-                          shadowColor: shadowColor,
-                          shape: modalType.shapeBorder,
-                          clipBehavior: clipBehavior,
-                          child: LayoutBuilder(
-                            builder: (_, constraints) {
-                              return modalType.decoratePageContent(
-                                context,
-                                WoltModalSheetAnimatedSwitcher(
-                                  woltModalType: modalType,
-                                  pageIndex: currentPageIndex,
-                                  pages: pages,
-                                  sheetWidth: constraints.maxWidth,
-                                  showDragHandle: showDragHandle,
-                                ),
-                                useSafeArea,
-                              );
-                            },
-                          ),
-                        ),
+              child: Material(
+                color: pageBackgroundColor,
+                elevation: modalElevation,
+                surfaceTintColor: surfaceTintColor,
+                shadowColor: shadowColor,
+                shape: modalType.shapeBorder,
+                clipBehavior: clipBehavior,
+                child: LayoutBuilder(
+                  builder: (_, constraints) {
+                    return modalType.decoratePageContent(
+                      context,
+                      WoltModalSheetAnimatedSwitcher(
+                        woltModalType: modalType,
+                        pageIndex: currentPageIndex,
+                        pages: pages,
+                        sheetWidth: constraints.maxWidth,
+                        showDragHandle: showDragHandle,
                       ),
-                    ),
-                  ),
+                      useSafeArea,
+                    );
+                  },
                 ),
               ),
-            ],
-          );
-          return Scaffold(
-            resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-            backgroundColor: Colors.transparent,
-            body: modalType.decorateModal(
-              context,
-              multiChildLayout,
-              useSafeArea,
             ),
-          );
-        },
-      ),
+          ),
+        );
+
+        final multiChildLayout = CustomMultiChildLayout(
+          delegate: _WoltModalMultiChildLayoutDelegate(
+            contentLayoutId: contentLayoutId,
+            barrierLayoutId: barrierLayoutId,
+            modalType: modalType,
+            textDirection: Directionality.of(context),
+          ),
+          children: [
+            LayoutId(
+              id: barrierLayoutId,
+              child: WoltAnimatedModalBarrier(
+                animationController: widget.route.animationController!,
+                barrierDismissible: widget.route.barrierDismissible,
+                onModalDismissedWithBarrierTap:
+                    widget.onModalDismissedWithBarrierTap,
+              ),
+            ),
+            LayoutId(
+              id: contentLayoutId,
+              child: widget.pageContentDecorator != null
+                  ? widget.pageContentDecorator!(pageContent)
+                  : pageContent,
+            ),
+          ],
+        );
+        return Scaffold(
+          resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+          backgroundColor: Colors.transparent,
+          body: modalType.decorateModal(
+            context,
+            multiChildLayout,
+            useSafeArea,
+          ),
+        );
+      },
     );
+
+    if (widget.modalDecorator != null) {
+      modalContent = widget.modalDecorator!(modalContent);
+    }
+
+    return modalContent;
   }
 
   void _onPageListBuilderNotifierValueUpdated() {

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -7,7 +7,8 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
   WoltModalSheetRoute({
     required this.pageListBuilderNotifier,
     this.pageIndexNotifier,
-    this.decorator,
+    this.pageContentDecorator,
+    this.modalDecorator,
     this.onModalDismissedWithBarrierTap,
     this.onModalDismissedWithDrag,
     this.modalBarrierColor,
@@ -26,7 +27,13 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
         _modalTypeBuilder = modalTypeBuilder,
         super(settings: settings);
 
-  Widget Function(Widget)? decorator;
+  /// Applies additional decorations to the modal page content excluding the
+  /// barrier. Use [modalDecorator] to apply decorations to the barrier and
+  /// the content.
+  Widget Function(Widget)? pageContentDecorator;
+
+  /// Applies additional decorations to the modal including the barrier and the content.
+  Widget Function(Widget)? modalDecorator;
 
   final ValueNotifier<WoltModalSheetPageListBuilder> pageListBuilderNotifier;
 
@@ -85,7 +92,8 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
   ) {
     return WoltModalSheet(
       route: this,
-      decorator: decorator,
+      pageContentDecorator: pageContentDecorator,
+      modalDecorator: modalDecorator,
       pageIndexNotifier: pageIndexNotifier ?? ValueNotifier(0),
       pageListBuilderNotifier: pageListBuilderNotifier,
       modalTypeBuilder: _determineCurrentModalType,

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -81,7 +81,8 @@ void main() {
             pageIndexNotifier: ValueNotifier(0),
             onModalDismissedWithBarrierTap: () {},
             onModalDismissedWithDrag: () {},
-            decorator: null,
+            pageContentDecorator: null,
+            modalDecorator: null,
             modalTypeBuilder: (_) => WoltModalType.bottomSheet(),
             transitionAnimationController: null,
             route: WoltModalSheetRoute<void>(
@@ -122,7 +123,8 @@ void main() {
             pageIndexNotifier: ValueNotifier(0),
             onModalDismissedWithBarrierTap: () {},
             onModalDismissedWithDrag: () {},
-            decorator: null,
+            pageContentDecorator: null,
+            modalDecorator: null,
             modalTypeBuilder: (_) => WoltModalType.bottomSheet(),
             transitionAnimationController: null,
             route: WoltModalSheetRoute<void>(


### PR DESCRIPTION
## Summary

This PR refactors the modal decoration mechanism to separate the decoration of the modal barrier + content from the decoration of the content only. This also aligns it with the WoltModalType class methods, and resolves the existing issue with the decorator context (see [comment](https://github.com/woltapp/wolt_modal_sheet/pull/203#issuecomment-2222520519)). 

Methods in `WoltModalType` class: `decoratePageContent` and `decorateModal`:

```dart
  /// Applies additional decorations to the modal page content.
  ///
  /// This method can be overridden to provide custom decorations such as safe area padding
  /// adjustments inside the modal page content. By default, it does not apply any decoration.
  /// See the [WoltBottomSheetType] for an example of how overriding this method could be used to
  /// fill the bottom safe area.
  Widget decoratePageContent(
    BuildContext context,
    Widget child,
    bool useSafeArea,
  ) =>
      child;

  /// Applies additional decorations to the modal content.
  ///
  /// This method can be overridden to provide custom decorations such as safe area padding
  /// adjustments around the modal including the barrier. By default, it applies safe area
  /// constraints if [useSafeArea] is `true`.
  Widget decorateModal(
    BuildContext context,
    Widget modal,
    bool useSafeArea,
  ) =>
      useSafeArea ? SafeArea(child: modal) : modal;
```

This PR introduces `pageContentDecorator` and `modalDecorator`:

```dart
  /// Applies additional decorations to the modal page content excluding the
  /// barrier. Use [modalDecorator] to apply decorations to the barrier and
  /// the content.
  Widget Function(Widget)? pageContentDecorator;

  /// Applies additional decorations to the modal including the barrier and the content.
  Widget Function(Widget)? modalDecorator;
```

## Changes Made to Decorator Functions

### Removed:

```dart
final Widget Function(Widget)? decorator;
Widget Function(Widget) get _decorator => widget.decorator ?? (widget) => Builder(builder: (_) => widget);
```

### Added:

```dart
final Widget Function(Widget)? pageContentDecorator;
final Widget Function(Widget)? modalDecorator;
Widget Function(Widget) get _pageContentDecorator => widget.pageContentDecorator ?? (widget) => Builder(builder: (_) => widget);
Widget Function(Widget) get _modalDecorator => widget.modalDecorator ?? (widget) => Builder(builder: (_) => widget);
```


### Benefits

The decorator function is split into `pageContentDecorator` and `modalDecorator`. This fixes the issue stated by @vishna in this [comment](https://github.com/woltapp/wolt_modal_sheet/pull/203#issuecomment-2222520519). Previously, the decorator function only decorated the page modal content, leading to errors when the pageListBuilder created the pages because the decorator context was built after the pages are built.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)