### PR TITLE
Adjustment: Renamed WoltModalSheetRoute routeSettings to settings

### DIFF
--- a/coffee_maker_navigator_2/lib/ui/orders/view/widgets/coffee_order_list_view_for_step.dart
+++ b/coffee_maker_navigator_2/lib/ui/orders/view/widgets/coffee_order_list_view_for_step.dart
@@ -71,7 +71,7 @@ void _onCoffeeOrderSelectedInReadyState(
   final model = context.read<OrdersScreenViewModel>();
 
   WoltModalSheet.show(
-    routeSettings: const RouteSettings(
+    settings: const RouteSettings(
         name: CoffeeOrderListViewForStep.modalRouteSettingName),
     context: context,
     pageListBuilder: (context) => [

--- a/coffee_maker_navigator_2/lib/ui/router/entities/app_route_page.dart
+++ b/coffee_maker_navigator_2/lib/ui/router/entities/app_route_page.dart
@@ -110,7 +110,7 @@ class OnboardingModalRoutePage extends AppRoutePage<void> {
   @override
   Route<void> createRoute(BuildContext context) {
     return WoltModalSheetRoute(
-      routeSettings: this,
+      settings: this,
       pageListBuilderNotifier: ValueNotifier(
         (context) => [OnboardingModalSheetPage()],
       ),
@@ -138,7 +138,7 @@ class GrindCoffeeModalRoutePage extends AppRoutePage<void> {
   @override
   Route<void> createRoute(BuildContext context) {
     return WoltModalSheetRoute(
-      routeSettings: this,
+      settings: this,
       pageListBuilderNotifier: ValueNotifier(
         (context) => [
           GrindOrRejectModalPage(coffeeOrderId, onCoffeeOrderStatusChange),

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -110,7 +110,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   ///   - `barrierDismissible`: Whether the modal can be dismissed by tapping the barrier.
   ///   - `enableDrag`: Whether the modal can be dismissed by dragging.
   ///   - `showDragHandle`: Whether to show a handle to indicate the modal can be dragged.
-  ///   - `routeSettings`: Additional settings for the modal route.
+  ///   - `settings`: Additional settings for the modal route.
   ///   - `transitionDuration`: Duration of the transition animations.
   ///   - `onModalDismissedWithBarrierTap`: Callback for when the modal is dismissed by tapping the barrier.
   ///   - `onModalDismissedWithDrag`: Callback for when the modal is dismissed by dragging.
@@ -130,7 +130,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool? barrierDismissible,
     bool? enableDrag,
     bool? showDragHandle,
-    RouteSettings? routeSettings,
+    RouteSettings? settings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
     VoidCallback? onModalDismissedWithDrag,
@@ -148,7 +148,7 @@ class WoltModalSheet<T> extends StatefulWidget {
       barrierDismissible: barrierDismissible,
       enableDrag: enableDrag,
       showDragHandle: showDragHandle,
-      routeSettings: routeSettings,
+      settings: settings,
       transitionDuration: transitionDuration,
       onModalDismissedWithBarrierTap: onModalDismissedWithBarrierTap,
       onModalDismissedWithDrag: onModalDismissedWithDrag,
@@ -176,7 +176,7 @@ class WoltModalSheet<T> extends StatefulWidget {
   ///   - `barrierDismissible`: Whether the modal can be dismissed by tapping the barrier.
   ///   - `enableDrag`: Whether the modal can be dismissed by dragging.
   ///   - `showDragHandle`: Whether to show a handle to indicate the modal can be dragged.
-  ///   - `routeSettings`: Additional settings for the modal route.
+  ///   - `settings`: Additional settings for the modal route.
   ///   - `transitionDuration`: Duration of the transition animations.
   ///   - `onModalDismissedWithBarrierTap`: Callback for when the modal is dismissed by tapping the barrier.
   ///   - `onModalDismissedWithDrag`: Callback for when the modal is dismissed by dragging.
@@ -197,7 +197,7 @@ class WoltModalSheet<T> extends StatefulWidget {
     bool? barrierDismissible,
     bool? enableDrag,
     bool? showDragHandle,
-    RouteSettings? routeSettings,
+    RouteSettings? settings,
     Duration? transitionDuration,
     VoidCallback? onModalDismissedWithBarrierTap,
     VoidCallback? onModalDismissedWithDrag,
@@ -212,7 +212,7 @@ class WoltModalSheet<T> extends StatefulWidget {
         pageIndexNotifier: pageIndexNotifier ?? ValueNotifier(0),
         pageListBuilderNotifier: pageListBuilderNotifier,
         modalTypeBuilder: modalTypeBuilder,
-        routeSettings: routeSettings,
+        settings: settings,
         barrierDismissible: barrierDismissible,
         enableDrag: enableDrag,
         showDragHandle: showDragHandle,

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -17,14 +17,14 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     bool? useSafeArea,
     bool? barrierDismissible,
     AnimationController? transitionAnimationController,
-    RouteSettings? routeSettings,
+    RouteSettings? settings,
   })  : _enableDrag = enableDrag,
         _showDragHandle = showDragHandle,
         _useSafeArea = useSafeArea ?? true,
         _transitionAnimationController = transitionAnimationController,
         _barrierDismissible = barrierDismissible,
         _modalTypeBuilder = modalTypeBuilder,
-        super(settings: routeSettings);
+        super(settings: settings);
 
   Widget Function(Widget)? decorator;
 

--- a/playground_navigator2/lib/router/router_pages/sheet_page.dart
+++ b/playground_navigator2/lib/router/router_pages/sheet_page.dart
@@ -25,7 +25,7 @@ class SheetPage extends Page<void> {
       onModalDismissedWithBarrierTap: () {
         context.read<RouterCubit>().closeSheet();
       },
-      routeSettings: this,
+      settings: this,
     );
   }
 


### PR DESCRIPTION
## Description

In order to stay consistent with the Router API of Flutter, we should rename routeSettings field as [settings](https://api.flutter.dev/flutter/widgets/Route/settings.html) field.

## Related Issues

fix: [Rename [WoltModalSheetRoute.routeSettings] fields as [WoltModalSheetRoute.settings]](https://github.com/woltapp/wolt_modal_sheet/issues/198)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

