### PR TITLE
Fix: Consider directionality for pagination animation

### DIFF
--- a/lib/src/content/components/paginating_group/main_content_animated_builder.dart
+++ b/lib/src/content/components/paginating_group/main_content_animated_builder.dart
@@ -77,6 +77,7 @@ class _MainContentAnimatedBuilderState
                 sheetWidth: widget.sheetWidth,
                 screenWidth: screenWidth,
                 isForwardMove: widget.forwardMove,
+                isLTR: Directionality.of(context) == TextDirection.ltr,
               ),
               child: widget.child,
             ),

--- a/lib/src/content/components/paginating_group/main_content_animated_builder.dart
+++ b/lib/src/content/components/paginating_group/main_content_animated_builder.dart
@@ -77,7 +77,7 @@ class _MainContentAnimatedBuilderState
                 sheetWidth: widget.sheetWidth,
                 screenWidth: screenWidth,
                 isForwardMove: widget.forwardMove,
-                isLTR: Directionality.of(context) == TextDirection.ltr,
+                textDirection: Directionality.of(context),
               ),
               child: widget.child,
             ),

--- a/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
+++ b/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
@@ -60,17 +60,25 @@ enum WoltModalSheetPageTransitionState {
     }
   }
 
+  /// Returns an animation for the main content slide position based on the
+  /// provided parameters, supporting both LTR and RTL directions.
   Animation<Offset> mainContentSlidePosition(
     AnimationController controller,
     WoltModalSheetPaginationAnimationStyle style, {
     required double sheetWidth,
     required double screenWidth,
     required bool isForwardMove,
+    required bool isLTR, // New parameter to determine the text direction
   }) {
+    // Determine the direction multiplier based on isLTR and isForwardMove.
+    final directionMultiplier = (isLTR ? 1 : -1) * (isForwardMove ? 1 : -1);
+
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
-        final incomingBeginOffset = Offset(
-            sheetWidth * 0.3 * (isForwardMove ? 1 : -1) / screenWidth, 0);
+        // Calculate the incoming begin offset using directionMultiplier.
+        final incomingBeginOffset =
+            Offset(sheetWidth * 0.3 * directionMultiplier / screenWidth, 0);
+
         return Tween<Offset>(
           begin:
               style.incomingMainContentSlideBeginOffset ?? incomingBeginOffset,
@@ -81,16 +89,19 @@ enum WoltModalSheetPageTransitionState {
             curve: style.mainContentIncomingSlidePositionCurve,
           ),
         );
+
       case WoltModalSheetPageTransitionState.outgoing:
-        final outgoingEndOffset = Offset(
-            sheetWidth * 0.3 * (isForwardMove ? -1 : 1) / screenWidth, 0);
+        // Calculate the outgoing end offset using directionMultiplier.
+        final outgoingEndOffset =
+            Offset(sheetWidth * 0.3 * -directionMultiplier / screenWidth, 0);
+
         return Tween<Offset>(
           begin: style.outgoingMainContentSlideBeginOffset,
           end: style.outgoingMainContentSlideEndOffset ?? outgoingEndOffset,
         ).animate(
           CurvedAnimation(
             parent: controller,
-            curve: style.mainContentIncomingSlidePositionCurve,
+            curve: style.mainContentOutgoingSlidePositionCurve,
           ),
         );
     }

--- a/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
+++ b/lib/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart
@@ -68,14 +68,13 @@ enum WoltModalSheetPageTransitionState {
     required double sheetWidth,
     required double screenWidth,
     required bool isForwardMove,
-    required bool isLTR, // New parameter to determine the text direction
+    required TextDirection textDirection,
   }) {
-    // Determine the direction multiplier based on isLTR and isForwardMove.
-    final directionMultiplier = (isLTR ? 1 : -1) * (isForwardMove ? 1 : -1);
+    final directionMultiplier = (textDirection == TextDirection.ltr ? 1 : -1) *
+        (isForwardMove ? 1 : -1);
 
     switch (this) {
       case WoltModalSheetPageTransitionState.incoming:
-        // Calculate the incoming begin offset using directionMultiplier.
         final incomingBeginOffset =
             Offset(sheetWidth * 0.3 * directionMultiplier / screenWidth, 0);
 
@@ -91,7 +90,6 @@ enum WoltModalSheetPageTransitionState {
         );
 
       case WoltModalSheetPageTransitionState.outgoing:
-        // Calculate the outgoing end offset using directionMultiplier.
         final outgoingEndOffset =
             Offset(sheetWidth * 0.3 * -directionMultiplier / screenWidth, 0);
 


### PR DESCRIPTION
## Summary

ThisPR introduces support for both Left-to-Right (LTR) and Right-to-Left (RTL) text directions in the slide animation logic for modal sheet page transitions. The mainContentSlidePosition method is updated to handle different slide directions based on a new `isLTR` parameter. 

## Changes

Calculated directionMultiplier based on `isLTR` and `isForwardMove` to correctly adjust the animation direction.
For LTR (isLTR = true), the multiplier is 1 for forward moves and -1 for backward moves.
For RTL (isLTR = false), the multiplier is -1 for forward moves and 1 for backward moves.

| Before LTR | After LTR |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/842edbdb-6a06-4b6a-b512-696eda3ee86f"> | <video src="https://github.com/user-attachments/assets/7ee80d5f-74f1-4d25-be76-fe7e0da535ff"> |

| Before RTL | After RTL |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fdcc8bb6-ffb7-4ef0-b89e-06ecbc60f28b"> | <video src="https://github.com/user-attachments/assets/a9c2f2c3-3c13-47fd-afca-0da637fe7d7d"> |

## Related Issues

Fixes https://github.com/woltapp/wolt_modal_sheet/issues/266

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md


https://github.com/user-attachments/assets/0b89e936-b90e-469e-907e-228e4c357607

