### PR TITLE
Remove deprecated mainContentSlivers field in SliverWoltModalSheetPage

### DIFF
--- a/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/ready/offer_recommendation_modal_page.dart
+++ b/coffee_maker_navigator_2/lib/ui/orders/view/modal_pages/ready/offer_recommendation_modal_page.dart
@@ -48,7 +48,7 @@ class OfferRecommendationModalPage {
       pageTitle: const ModalSheetTitle(pageTitle),
       trailingNavBarWidget: const WoltModalSheetCloseButton(),
       leadingNavBarWidget: const WoltModalSheetBackButton(),
-      mainContentSlivers: [
+      mainContentSliversBuilder: (context) => [
         SliverList(
           delegate: SliverChildBuilderDelegate(
             (_, index) {

--- a/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
+++ b/lib/src/content/components/main_content/wolt_modal_sheet_main_content.dart
@@ -84,11 +84,7 @@ class WoltModalSheetMainContent extends StatelessWidget {
               childCount: 2,
             ),
           ),
-        if (page.mainContentSliversBuilder == null)
-          // ignore: deprecated_member_use_from_same_package
-          ...page.mainContentSlivers!
-        else
-          ...page.mainContentSliversBuilder!(context),
+        ...page.mainContentSliversBuilder(context),
         if (shouldFillRemaining)
           const SliverFillRemaining(
             hasScrollBody: false,

--- a/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
+++ b/lib/src/modal_page/sliver_wolt_modal_sheet_page.dart
@@ -27,7 +27,7 @@ import 'package:wolt_modal_sheet/src/wolt_modal_sheet.dart';
 /// intuitive user experience, with flexible customization options for various use cases.
 ///
 /// [SliverWoltModalSheetPage] utilizes Flutter's sliver widgets for its main content,
-/// encapsulated in [mainContentSlivers]. Slivers are specialized Flutter widgets that
+/// built with [mainContentSliversBuilder]. Slivers are specialized Flutter widgets that
 /// create elements with custom scroll effects and are a fundamental part of creating
 /// advanced scrollable layouts.
 ///
@@ -111,17 +111,10 @@ class SliverWoltModalSheetPage {
   /// be hidden or revealed  based on the page's scrolling behavior.
   final bool? isTopBarLayerAlwaysVisible;
 
-  /// This list of sliver widgets within the scrollable modal sheet is responsible for displaying
-  /// the main content inside the [CustomScrollView] of the modal sheet.
-  @Deprecated(
-      'Use mainContentSliversBuilder to gain access to BuildContext for dynamic widget creation.')
-  final List<Widget>? mainContentSlivers;
-
-  /// Similar to [mainContentSlivers] but exposes the enclosing [BuildContext].
   /// Use this method to dynamically build the list of sliver widgets within the modal sheet
   /// based on the available [BuildContext]. This approach is more flexible and recommended
   /// for most use cases.
-  final List<Widget> Function(BuildContext context)? mainContentSliversBuilder;
+  final List<Widget> Function(BuildContext context) mainContentSliversBuilder;
 
   /// A [Widget] representing the hero image displayed on top of the main content. A Hero Image
   /// is positioned at the top of the main content. This widget immediately grabs the user's
@@ -235,8 +228,7 @@ class SliverWoltModalSheetPage {
 
   /// Creates a page to be built within [WoltScrollableModalSheet].
   const SliverWoltModalSheetPage({
-    this.mainContentSlivers,
-    this.mainContentSliversBuilder,
+    required this.mainContentSliversBuilder,
     this.id,
     this.pageTitle,
     this.navBarHeight,
@@ -258,11 +250,8 @@ class SliverWoltModalSheetPage {
     this.isTopBarLayerAlwaysVisible,
     this.resizeToAvoidBottomInset,
     this.useSafeArea,
-  })  : assert(!(topBar != null && hasTopBarLayer == false),
-            "When topBar is provided, hasTopBarLayer must not be false"),
-        assert(
-            (mainContentSlivers != null) ^ (mainContentSliversBuilder != null),
-            "Either mainContentSlivers or mainContentSliversBuilder must be provided, but not both");
+  }) : assert(!(topBar != null && hasTopBarLayer == false),
+            "When topBar is provided, hasTopBarLayer must not be false");
 
   SliverWoltModalSheetPage copyWith({
     Object? id,
@@ -325,6 +314,7 @@ class SliverWoltModalSheetPage {
   /// [WoltModalSheetPage] or [NonScrollingWoltModalSheetPage] and you want to replace the main
   /// content of the page with a single [child] Widget.
   SliverWoltModalSheetPage copyWithChild({
+    required Widget child,
     Object? id,
     Widget? pageTitle,
     Widget? topBarTitle,
@@ -346,7 +336,6 @@ class SliverWoltModalSheetPage {
     Widget? trailingNavBarWidget,
     bool? resizeToAvoidBottomInset,
     bool? useSafeArea,
-    Widget? child,
   }) {
     return SliverWoltModalSheetPage(
       id: id ?? this.id,
@@ -356,9 +345,7 @@ class SliverWoltModalSheetPage {
       hasTopBarLayer: hasTopBarLayer ?? this.hasTopBarLayer,
       isTopBarLayerAlwaysVisible:
           isTopBarLayerAlwaysVisible ?? this.isTopBarLayerAlwaysVisible,
-      mainContentSliversBuilder: child == null
-          ? mainContentSliversBuilder
-          : _mainContentBuilderFromChild(child),
+      mainContentSliversBuilder: _mainContentBuilderFromChild(child),
       heroImage: heroImage ?? this.heroImage,
       heroImageHeight: heroImageHeight ?? this.heroImageHeight,
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -378,7 +365,7 @@ class SliverWoltModalSheetPage {
     );
   }
 
-  List<Widget> Function(BuildContext context)? _mainContentBuilderFromChild(
+  List<Widget> Function(BuildContext context) _mainContentBuilderFromChild(
       Widget child) {
     if (this is WoltModalSheetPage) {
       return (_) => [


### PR DESCRIPTION
## Description

Removes the previously marked as deprecated mainContentSlivers in favor of `mainContentSliversBuilder` field.

#### Before

```dart
SliverWoltModalSheetPage(
  mainContentSlivers: [
    SliverList(
      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
        // Your list items
      }),
    ),
    // Other sliver widgets...
  ],
  // Additional page elements like pageTitle, topBarTitle, etc.
)
```

#### After

```dart
SliverWoltModalSheetPage(
  mainContentSliversBuilder: (context) => [
    SliverList(
      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
        // Your list items
      }),
    ),
    // Other sliver widgets...
  ],
  // Additional page elements like pageTitle, topBarTitle, etc.
)
```

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

