### PR TITLE
Remove KeyboardVisibilityListener dependency and add WoltKeyboardClosureListenerMixin

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:wolt_modal_sheet/src/content/components/main_content/wolt_modal_sheet_main_content.dart';
 import 'package:wolt_modal_sheet/src/content/components/main_content/wolt_modal_sheet_top_bar.dart';
 import 'package:wolt_modal_sheet/src/content/components/main_content/wolt_modal_sheet_top_bar_flow.dart';
@@ -11,7 +8,7 @@ import 'package:wolt_modal_sheet/src/content/components/paginating_group/paginat
 import 'package:wolt_modal_sheet/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart';
 import 'package:wolt_modal_sheet/src/content/wolt_modal_sheet_layout.dart';
 import 'package:wolt_modal_sheet/src/theme/wolt_modal_sheet_default_theme_data.dart';
-import 'package:wolt_modal_sheet/src/utils/soft_keyboard_closed_event.dart';
+import 'package:wolt_modal_sheet/src/utils/wolt_keyboard_closure_listener_mixin.dart';
 import 'package:wolt_modal_sheet/src/widgets/wolt_navigation_toolbar.dart';
 import 'package:wolt_modal_sheet/src/widgets/wolt_sticky_action_bar_wrapper.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
@@ -40,11 +37,12 @@ class WoltModalSheetAnimatedSwitcher extends StatefulWidget {
 
 class _WoltModalSheetAnimatedSwitcherState
     extends State<WoltModalSheetAnimatedSwitcher>
-    with TickerProviderStateMixin {
+    with
+        TickerProviderStateMixin,
+        WidgetsBindingObserver,
+        WoltKeyboardClosureListenerMixin {
   PaginatingWidgetsGroup? _incomingPageWidgets;
   PaginatingWidgetsGroup? _outgoingPageWidgets;
-
-  static const int _maxKeyboardAnimationDuration = 250;
 
   int get _pagesCount => widget.pages.length;
 
@@ -84,25 +82,6 @@ class _WoltModalSheetAnimatedSwitcherState
   ValueNotifier<double> get _currentPageScrollPosition =>
       _scrollPositions[_pageIndex];
 
-  /// Subscription for discovering the state of the soft-keyboard visibility
-  late StreamSubscription<bool> _softKeyboardVisibilitySubscription;
-
-  /// Value notifier for discovering when the soft-keyboard is dismissed. These events are
-  /// consumed by [WoltModalSheetTopBarFlow] and [WoltModalSheetTopBarTitleFlow] to trigger a
-  /// re-paint when keyboard is closing. This is needed to avoid the top bar from being stuck
-  /// when keyboard is closing.
-  ///
-  /// By default, the top bar visibility is synced with the scroll controller position. The
-  /// [WoltModalSheetTopBarFlow] and [WoltModalSheetTopBarTitleFlow] paints the top bar according
-  /// to the scroll position changes.
-  ///
-  /// When the keyboard appears the scroll controller receives scroll update events, which are
-  /// sent by the Flutter SDK. However, the keyboard closing events do not cause a change in the
-  /// scroll controller. Therefore, we need to manually trigger a re-paint when the keyboard is
-  /// closing.
-  final ValueNotifier<SoftKeyboardClosedEvent> _softKeyboardClosedNotifier =
-      ValueNotifier(const SoftKeyboardClosedEvent(eventId: 0));
-
   bool _isForwardMove = true;
 
   late bool _shouldAnimatePagination;
@@ -116,7 +95,6 @@ class _WoltModalSheetAnimatedSwitcherState
     _resetScrollPositions();
     _resetScrollControllers();
     _subscribeToCurrentPageScrollPositionChanges();
-    _subscribeToSoftKeyboardClosedEvent();
   }
 
   void _resetGlobalKeys() {
@@ -152,22 +130,6 @@ class _WoltModalSheetAnimatedSwitcherState
         }
       });
     }
-  }
-
-  void _subscribeToSoftKeyboardClosedEvent() {
-    _softKeyboardVisibilitySubscription =
-        KeyboardVisibilityController().onChange.listen((bool visible) async {
-      if (!visible) {
-        /// Wait for closing soft keyboard animation to finish before emitting new value.
-        await Future.delayed(
-          const Duration(milliseconds: _maxKeyboardAnimationDuration),
-        );
-        final int lastEventId = _softKeyboardClosedNotifier.value.eventId;
-        final newEventId = lastEventId + 1;
-        _softKeyboardClosedNotifier.value =
-            SoftKeyboardClosedEvent(eventId: newEventId);
-      }
-    });
   }
 
   @override
@@ -251,7 +213,6 @@ class _WoltModalSheetAnimatedSwitcherState
   @override
   void dispose() {
     _animationController?.dispose();
-    _softKeyboardVisibilitySubscription.cancel();
     for (final element in _scrollControllers) {
       element.dispose();
     }
@@ -355,7 +316,7 @@ class _WoltModalSheetAnimatedSwitcherState
           scrollController: _currentPageScrollController,
           titleKey: _pageTitleKey,
           topBarTitle: topBarTitle,
-          softKeyboardClosedListenable: _softKeyboardClosedNotifier,
+          softKeyboardClosedListenable: softKeyboardClosureListenable,
         );
       }
     }
@@ -396,7 +357,7 @@ class _WoltModalSheetAnimatedSwitcherState
                     page: _page,
                     scrollController: _currentPageScrollController,
                     titleKey: _pageTitleKey,
-                    softKeyboardClosedListenable: _softKeyboardClosedNotifier,
+                    softKeyboardClosedListenable: softKeyboardClosureListenable,
                   ))
             : const SizedBox.shrink(),
       ),

--- a/lib/src/utils/wolt_keyboard_closure_listener_mixin.dart
+++ b/lib/src/utils/wolt_keyboard_closure_listener_mixin.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/src/utils/soft_keyboard_closed_event.dart';
+
+/// Mixin [WoltKeyboardClosureListenerMixin] adds functionality to track the soft keyboard's
+/// visibility within the application lifecycle. It leverages the [WidgetsBindingObserver]
+/// to monitor changes in the UI metrics, particularly to detect when the keyboard is shown
+/// or hidden.
+///
+/// When the keyboard transitions from visible to hidden, the mixin updates a [ValueNotifier]
+/// with a new [SoftKeyboardClosedEvent], incrementing an event ID to signal that the keyboard
+/// has closed. This can be used to trigger updates or actions when the keyboard hides,
+/// such as resizing layouts or adjusting UI elements.
+///
+/// To use this mixin, include it in any [State] class of a [StatefulWidget] and ensure
+/// to call `super.initState()` and `super.dispose()` to correctly manage the mixin's lifecycle.
+mixin WoltKeyboardClosureListenerMixin<T extends StatefulWidget>
+    on State<T>, WidgetsBindingObserver {
+  bool _keyboardWasVisible = false;
+  late ValueNotifier<SoftKeyboardClosedEvent> _keyboardClosedNotifier;
+
+  /// Initializes the state, setting up the observer and initializing the notifier.
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _keyboardClosedNotifier = ValueNotifier(const SoftKeyboardClosedEvent(
+        eventId: 0)); // Provide an appropriate initial event ID.
+  }
+
+  /// Cleans up by removing the observer to avoid memory leaks.
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  /// Reacts to changes in system metrics, particularly those affecting the bottom
+  /// view inset, which typically represents the soft keyboard. If the keyboard
+  /// was previously visible and is now hidden, it increments the event ID and updates
+  /// the notifier.
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
+    bool keyboardVisible = viewInsets > 0;
+
+    if (_keyboardWasVisible && !keyboardVisible) {
+      final int lastEventId = _keyboardClosedNotifier.value.eventId;
+      final newEventId = lastEventId + 1;
+      _keyboardClosedNotifier.value =
+          SoftKeyboardClosedEvent(eventId: newEventId);
+    }
+
+    _keyboardWasVisible = keyboardVisible;
+  }
+
+  /// Returns a ValueNotifier<SoftKeyboardClosedEvent> to provide access to the notifier
+  /// from the widget tree, allowing other widgets to listen and react to keyboard closure events.
+  ValueListenable<SoftKeyboardClosedEvent> get softKeyboardClosureListenable =>
+      _keyboardClosedNotifier;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_keyboard_visibility: ^6.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Description

This PR introduces the `WoltKeyboardClosureListenerMixin` mixin and removes the [FlutterKeyboardVisibility](https://github.com/MisterJimson/flutter_keyboard_visibility) package dependency. The purpose of this mixin is to track the visibility of the soft keyboard by monitoring the changes in the system's view insets and using the WidgetsBindingObserver.

- Utilizes the WidgetsBindingObserver to listen to changes in UI metrics, specifically to detect keyboard appearance and disappearance.
- Updates a ValueNotifier<SoftKeyboardClosedEvent> with a new event ID whenever the keyboard closes. This is important for widgets that need to adjust their layout or perform specific actions when the keyboard is hidden. For example, re-painting the top bar and top bar title.

| Android | iOS |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ede6a08a-14c3-41da-85f2-04f3c4a8cc8a"> | <video src="https://github.com/user-attachments/assets/472fbc71-212c-42b9-9edd-fd5b638dae51"> | 

## Related Issues
#210 


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

