### PR TITLE
[Example app] Add sliver padding to bottom to demonstrate how to show the area behind the sticky action bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
 
   return MaterialApp(
     themeMode: _isLightTheme ? ThemeMode.light : ThemeMode.dark,
-    theme: ThemeData.light(useMaterial3: true).copyWith(
+    theme: ThemeData.light().copyWith(
       extensions: const <ThemeExtension>[
         WoltModalSheetThemeData(
           heroImageHeight: _heroImageHeight,
@@ -295,7 +295,7 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
         ),
       ],
     ),
-    darkTheme: ThemeData.dark(useMaterial3: true).copyWith(
+    darkTheme: ThemeData.dark().copyWith(
       extensions: const <ThemeExtension>[
         WoltModalSheetThemeData(
           topBarShadowColor: _darkThemeShadowColor,

--- a/demo_ui_components/lib/src/theme_data/app_theme_data.dart
+++ b/demo_ui_components/lib/src/theme_data/app_theme_data.dart
@@ -25,7 +25,6 @@ class AppThemeData {
       cardTheme: _cardThemeData,
       outlinedButtonTheme: _outlinedButtonThemeData(textTheme),
       navigationBarTheme: _navigationBarThemeData(textTheme),
-      useMaterial3: true,
       colorScheme: colorScheme,
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -106,6 +106,17 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
           icon: const Icon(Icons.close),
           onPressed: Navigator.of(modalSheetContext).pop,
         ),
+        stickyActionBar: Padding(
+          padding: const EdgeInsets.all(_pagePadding),
+          child: ElevatedButton(
+            onPressed: Navigator.of(modalSheetContext).pop,
+            child: const SizedBox(
+              height: _buttonHeight,
+              width: double.infinity,
+              child: Center(child: Text('Close')),
+            ),
+          ),
+        ),
         mainContentSliversBuilder: (context) => [
           SliverGrid(
             gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -123,6 +134,18 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
             delegate: SliverChildBuilderDelegate(
               (_, index) => ColorTile(color: materialColorsInSliverList[index]),
               childCount: materialColorsInSliverList.length,
+            ),
+          ),
+          const SliverPadding(
+            padding: EdgeInsets.only(bottom: _bottomPaddingForButton),
+            sliver: SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.all(_pagePadding),
+                child: Text(
+                  'Last Item',
+                  textAlign: TextAlign.center,
+                ),
+              ),
             ),
           ),
         ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -154,7 +154,7 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
 
     return MaterialApp(
       themeMode: _isLightTheme ? ThemeMode.light : ThemeMode.dark,
-      theme: ThemeData.light(useMaterial3: true).copyWith(
+      theme: ThemeData.light().copyWith(
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
             heroImageHeight: _heroImageHeight,
@@ -164,7 +164,7 @@ Pagination involves a sequence of screens the user navigates sequentially. We ch
           ),
         ],
       ),
-      darkTheme: ThemeData.dark(useMaterial3: true).copyWith(
+      darkTheme: ThemeData.dark().copyWith(
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
             topBarShadowColor: _darkThemeShadowColor,

--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -69,7 +69,6 @@ class _DemoAppState extends State<DemoApp> {
       theme: ThemeData.light().copyWith(
         brightness: Brightness.light,
         inputDecorationTheme: inputDecorationTheme,
-        useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(seedColor: WoltColors.blue),
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
@@ -78,11 +77,10 @@ class _DemoAppState extends State<DemoApp> {
           ),
         ],
       ),
-      darkTheme: ThemeData.dark(useMaterial3: true).copyWith(
+      darkTheme: ThemeData.dark().copyWith(
         brightness: Brightness.dark,
         inputDecorationTheme: inputDecorationTheme,
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF009DE0)),
-        useMaterial3: true,
         extensions: const <ThemeExtension>[
           WoltModalSheetThemeData(
             backgroundColor: Color(0xFF242424),

--- a/playground_navigator2/lib/main.dart
+++ b/playground_navigator2/lib/main.dart
@@ -72,7 +72,6 @@ class _DemoAppState extends State<DemoApp> {
             focusColor: WoltColors.blue,
           ),
           primaryColor: WoltColors.blue,
-          useMaterial3: true,
           fontFamily: 'Inter',
           textTheme: TextTheme(
             headlineMedium: TextStyle(


### PR DESCRIPTION
## Description

This PR updates the example app and demonstrates how to handle the area behind the sticky action bar in sliver list.


## Related Issues

https://github.com/woltapp/wolt_modal_sheet/issues/305

<video src="https://github.com/user-attachments/assets/9b7aff40-2f5b-46ef-bfb8-0422e2006c2f">

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

