### PR TITLE
fix gesture detector onDrag callback

### DIFF
--- a/lib/src/widgets/wolt_modal_sheet_drag_to_dismiss_detector.dart
+++ b/lib/src/widgets/wolt_modal_sheet_drag_to_dismiss_detector.dart
@@ -63,17 +63,17 @@ class WoltModalSheetDragToDismissDetector extends StatelessWidget {
       },
       child: GestureDetector(
         excludeFromSemantics: true,
-        onVerticalDragUpdate: (details) => isVerticalDismissAllowed
-            ? _handleVerticalDragUpdate(details)
+        onVerticalDragUpdate: isVerticalDismissAllowed
+            ? (details) => _handleVerticalDragUpdate(details)
             : null,
-        onVerticalDragEnd: (details) => isVerticalDismissAllowed
-            ? _handleVerticalDragEnd(context, details)
+        onVerticalDragEnd: isVerticalDismissAllowed
+            ? (details) => _handleVerticalDragEnd(context, details)
             : null,
-        onHorizontalDragUpdate: (details) => isHorizontalDismissAllowed
-            ? _handleHorizontalDragUpdate(context, details)
+        onHorizontalDragUpdate: isHorizontalDismissAllowed
+            ? (details) => _handleHorizontalDragUpdate(context, details)
             : null,
-        onHorizontalDragEnd: (details) => isHorizontalDismissAllowed
-            ? _handleHorizontalDragEnd(context, details)
+        onHorizontalDragEnd: isHorizontalDismissAllowed
+            ? (details) => _handleHorizontalDragEnd(context, details)
             : null,
         child: child,
       ),


### PR DESCRIPTION
I'm sorry for the failed first attempt. I'm not really used to doing this. I hope everything is fine now.

I fixed the issue with the GestureDetector's onDrag callback in the WoltModalSheetDragToDismissDetector.

Previously, the callbacks were not properly set to null when they needed to be disabled, which caused them to remain active unintentionally.

This is realated to issue #322