### PR TITLE
Fix modalDecorator Context Wrapping in WoltModalSheet

### DIFF
--- a/lib/src/modal_type/wolt_alert_dialog_type.dart
+++ b/lib/src/modal_type/wolt_alert_dialog_type.dart
@@ -9,7 +9,7 @@ class WoltAlertDialogType extends WoltDialogType {
 
   @override
   BoxConstraints layoutModal(Size availableSize) {
-    late double width;
+    double width;
     final availableWidth = availableSize.width;
     final screenType = WoltBreakpoints.getScreenTypeForWidth(availableWidth);
 

--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -57,7 +57,7 @@ class WoltDialogType extends WoltModalType {
     final double availableWidth = availableSize.width;
     final double availableHeight = availableSize.height;
 
-    late double width;
+    double width;
 
     if (availableWidth > horizontalBreakpoint) {
       width = minModalWidth;

--- a/lib/src/wolt_modal_sheet.dart
+++ b/lib/src/wolt_modal_sheet.dart
@@ -311,19 +311,18 @@ class WoltModalSheetState extends State<WoltModalSheet> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_pages.isEmpty) {
-      // Get the initial page list from the initially provided pageListBuilder.
-      final initialPages = widget.pageListBuilderNotifier.value(context);
-      assert(initialPages.isNotEmpty,
-          'pageListBuilder must return a non-empty list.');
-      _pages = initialPages;
+  Widget build(BuildContext context) {
+    final modalDecorator = widget.modalDecorator;
+    if (modalDecorator != null) {
+      return modalDecorator(Builder(builder: (decoratedContext) {
+        return _buildModalContent(decoratedContext);
+      }));
     }
+
+    return _buildModalContent(context);
   }
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildModalContent(BuildContext context) {
     final themeData = Theme.of(context).extension<WoltModalSheetThemeData>();
     final defaultThemeData = WoltModalSheetDefaultThemeData(context);
     final modalType =
@@ -332,8 +331,17 @@ class WoltModalSheetState extends State<WoltModalSheet> {
     Widget modalContent = ValueListenableBuilder(
       valueListenable: widget.pageIndexNotifier,
       builder: (context, currentPageIndex, __) {
+        if (_pages.isEmpty) {
+          final initialPages = widget.pageListBuilderNotifier.value(context);
+          assert(
+            initialPages.isNotEmpty,
+            'pageListBuilder must return a non-empty list.',
+          );
+          _pages = initialPages;
+        }
         final pages = _pages;
         final page = pages[currentPageIndex];
+
         final enableDrag = page.enableDrag ??
             widget.enableDrag ??
             modalType.isDragToDismissEnabled ??
@@ -440,10 +448,6 @@ class WoltModalSheetState extends State<WoltModalSheet> {
         );
       },
     );
-
-    if (widget.modalDecorator != null) {
-      modalContent = widget.modalDecorator!(modalContent);
-    }
 
     return modalContent;
   }

--- a/playground/lib/home/home_screen.dart
+++ b/playground/lib/home/home_screen.dart
@@ -223,7 +223,19 @@ class _HomeScreenState extends State<HomeScreen> {
                               Navigator.of(context).pop();
                             },
                             pageListBuilder: (BuildContext context) {
+                              assert(
+                                _MyModalDecorator.of(context) != null,
+                                'This is added to test the modalDecorator. It will throw a '
+                                'runtime error if the modalDecorator is broken.',
+                              );
+
                               return [RootSheetPage.build(context)];
+                            },
+                            modalDecorator: (child) {
+                              return _MyModalDecorator(
+                                data: 'Hello from _MyModalDecorator',
+                                child: child,
+                              );
                             },
                           );
                         },
@@ -262,6 +274,24 @@ class _HomeScreenState extends State<HomeScreen> {
           },
           child: const Icon(Icons.notifications_active),
         ));
+  }
+}
+
+class _MyModalDecorator extends InheritedWidget {
+  final String data;
+
+  const _MyModalDecorator({
+    required this.data,
+    required Widget child,
+  }) : super(child: child);
+
+  static _MyModalDecorator? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<_MyModalDecorator>();
+  }
+
+  @override
+  bool updateShouldNotify(_MyModalDecorator oldWidget) {
+    return data != oldWidget.data;
   }
 }
 


### PR DESCRIPTION
## Description

The `modalDecorator` in `WoltModalSheet` was not correctly wrapping the modal content, causing inherited widgets or providers added via modalDecorator to be inaccessible within `pageListBuilder`. This resulted in exceptions like `ProviderNotFoundException` when attempting to access context-dependent widgets inside pageListBuilder.

## Related Issues

Wolt internal problem.

## Solution
The fix involves adjusting the build process in WoltModalSheet to ensure that the `modalDecorator` is applied before `pageListBuilder` is called. This way, the `context` used within `pageListBuilder` includes the inherited widgets or providers added by modalDecorator.

### Changes Made
1. Modified the build Method in WoltModalSheetState:

- Checked if a `modalDecorator` is provided.
- If so, wrapped the modal content with `modalDecorator` using a `Builder` widget to create a new `BuildContext` that includes the decorations.
- Moved the original build logic into a new `_buildModalContent` method, which now uses the decorated context.

2. Updated Context Usage in _buildModalContent:

- Ensured that all references to context inside _buildModalContent and any methods it calls use the BuildContext that includes the decorations applied by modalDecorator.
- Adjusted Initialization of _pages in didChangeDependencies by moving the initialization of _pages into `_buildModalContent` to ensure it has access to the decorated context.

### Example usage after fix

```dart
WoltModalSheet.show(
  context: context,
  pageListBuilder: (BuildContext context) {
    final inheritedWidget = MyInheritedWidget.of(context);
    final data = inheritedWidget?.data ?? 'No data found';
    // Use 'data' as needed in your page
    return [RootSheetPage.build(context, data)];
  },
  modalDecorator: (child) {
    return MyInheritedWidget(
      data: 'Hello from InheritedWidget',
      child: child,
    );
  },
  // ... other parameters ...
);

```

## How to test?
- Clone repository.
- Run the playground app, and see that it works.
- Revert the changes in wolt_modal_sheet.dart
- Run the playground app, and see that it is gives exception when `Show Modal Sheet` is pressed.

| Broken | Working |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/44502c89-d693-4463-9a62-4c3d80a33ffa"> | <img src="https://github.com/user-attachments/assets/8e6dcf8b-32c6-4a21-b63d-93c0a64a2581"> |

## Impact

- Developers can now use `modalDecorator` to wrap the entire modal, including the `barrier` and `content`, with widgets that provide inherited context.
- State Management: Facilitates better state management practices by allowing providers or inherited widgets to be accessible throughout the modal's content.
- Backward Compatibility: This change is backward-compatible and does not affect existing implementations that do not use modalDecorator.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

