### PR TITLE
Bump min Flutter SDK version to 3.16.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2.16.0
         with:
-          flutter-version: '3.13.0' # Uses the minimum supported version.
+          flutter-version: '3.16.0' # Uses the minimum supported version.
           channel: stable
       - name: Install DCM
         uses: CQLabs/setup-dcm@v1
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2.16.0
         with:
-          flutter-version: '3.13.0' # Uses the minimum supported version.
+          flutter-version: '3.16.0' # Uses the minimum supported version.
           channel: stable
       # Get Flutter version
       - name: Get Flutter version
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2.16.0
         with:
-          flutter-version: '3.13.0' # Uses the minimum supported version.
+          flutter-version: '3.16.0' # Uses the minimum supported version.
           channel: stable
       # Get Flutter version
       - name: Get Flutter version

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: subosito/flutter-action@v2.16.0
         with:
-          flutter-version: '3.13.0' # Uses the minimum supported version.
+          flutter-version: '3.16.0' # Uses the minimum supported version.
           channel: stable
       - run: flutter build web --release --web-renderer=canvaskit
         working-directory: ./coffee_maker

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,8 @@ dart_code_metrics:
     - avoid-dynamic: false
     - avoid-duplicate-test-assertions: false
     - prefer-correct-test-file-name: false
+    - avoid-suspicious-super-overrides: false
+    - avoid-collection-equality-checks: false
 
 analyzer:
   errors:

--- a/coffee_maker/pubspec.yaml
+++ b/coffee_maker/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/coffee_maker_navigator_2/pubspec.yaml
+++ b/coffee_maker_navigator_2/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/demo_ui_components/pubspec.yaml
+++ b/demo_ui_components/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 
 environment:
   sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/melos.yaml
+++ b/melos.yaml
@@ -3,12 +3,12 @@ repository: https://github.com/woltapp/wolt_modal_sheet
 
 packages:
   - . ## This is the root package
-  # - coffee_maker
-  # - coffee_maker_navigator_2
-  # - demo_ui_components
-  # - playground
-  # - playground_navigator2
-  # - wolt_di
+  - coffee_maker
+  - coffee_maker_navigator_2
+  - demo_ui_components
+  - playground
+  - playground_navigator2
+  - wolt_di
 
 command:
   bootstrap:
@@ -24,5 +24,3 @@ scripts:
     exec: dcm analyze .
   format:
     exec: dart format --set-exit-if-changed .
-  test:
-    exec: flutter test

--- a/melos.yaml
+++ b/melos.yaml
@@ -3,12 +3,12 @@ repository: https://github.com/woltapp/wolt_modal_sheet
 
 packages:
   - . ## This is the root package
-  - coffee_maker
-  - coffee_maker_navigator_2
-  - demo_ui_components
-  - playground
-  - playground_navigator2
-  - wolt_di
+  # - coffee_maker
+  # - coffee_maker_navigator_2
+  # - demo_ui_components
+  # - playground
+  # - playground_navigator2
+  # - wolt_di
 
 command:
   bootstrap:

--- a/playground/pubspec.yaml
+++ b/playground/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/playground_navigator2/lib/router/playground_router_delegate.dart
+++ b/playground_navigator2/lib/router/playground_router_delegate.dart
@@ -108,6 +108,8 @@ class PlaygroundRouterDelegate
   @override
   void dispose() {
     _cubitSubscription.cancel();
+    _pageIndexNotifier.dispose();
+    _pageListBuilderNotifier.dispose();
     super.dispose();
   }
 }

--- a/playground_navigator2/lib/router/router_pages/home_page.dart
+++ b/playground_navigator2/lib/router/router_pages/home_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:playground_navigator2/home/home_screen.dart';
 
 class HomePage extends Page<void> {
-  const HomePage() : super(key: const ValueKey('HomePage'), name: 'Home Screen');
+  const HomePage()
+      : super(key: const ValueKey('HomePage'), name: 'Home Screen');
 
   @override
   Route<void> createRoute(BuildContext context) {

--- a/playground_navigator2/lib/router/router_pages/home_page.dart
+++ b/playground_navigator2/lib/router/router_pages/home_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:playground_navigator2/home/home_screen.dart';
 
 class HomePage extends Page<void> {
-  const HomePage() : super(key: const ValueKey('HomePage'));
+  const HomePage() : super(key: const ValueKey('HomePage'), name: 'Home Screen');
 
   @override
   Route<void> createRoute(BuildContext context) {
@@ -11,7 +11,4 @@ class HomePage extends Page<void> {
       builder: (context) => const HomeScreen(),
     );
   }
-
-  @override
-  String get name => 'Home Screen';
 }

--- a/playground_navigator2/lib/router/router_pages/sheet_page.dart
+++ b/playground_navigator2/lib/router/router_pages/sheet_page.dart
@@ -7,7 +7,7 @@ class SheetPage extends Page<void> {
   const SheetPage({
     required this.pageIndexNotifier,
     required this.pageListBuilderNotifier,
-  }) : super(key: const ValueKey('SheetPage'));
+  }) : super(key: const ValueKey('SheetPage'), name: SheetPage.routeName);
 
   final ValueNotifier<int> pageIndexNotifier;
   final ValueNotifier<WoltModalSheetPageListBuilder> pageListBuilderNotifier;
@@ -28,7 +28,4 @@ class SheetPage extends Page<void> {
       settings: this,
     );
   }
-
-  @override
-  String get name => routeName;
 }

--- a/playground_navigator2/lib/router/router_pages/unknown_page.dart
+++ b/playground_navigator2/lib/router/router_pages/unknown_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:playground_navigator2/unknown/unknown_screen.dart';
 
 class UnknownPage extends Page<void> {
-  const UnknownPage() : super(key: const ValueKey('UnknownPage'));
+  const UnknownPage() : super(key: const ValueKey('UnknownPage'), name: 'Unknown Screen');
 
   @override
   Route<void> createRoute(BuildContext context) {
@@ -11,7 +11,4 @@ class UnknownPage extends Page<void> {
       builder: (context) => const UnknownScreen(),
     );
   }
-
-  @override
-  String get name => 'Unknown Screen';
 }

--- a/playground_navigator2/lib/router/router_pages/unknown_page.dart
+++ b/playground_navigator2/lib/router/router_pages/unknown_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:playground_navigator2/unknown/unknown_screen.dart';
 
 class UnknownPage extends Page<void> {
-  const UnknownPage() : super(key: const ValueKey('UnknownPage'), name: 'Unknown Screen');
+  const UnknownPage()
+      : super(key: const ValueKey('UnknownPage'), name: 'Unknown Screen');
 
   @override
   Route<void> createRoute(BuildContext context) {

--- a/playground_navigator2/pubspec.yaml
+++ b/playground_navigator2/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: '>=2.19.2 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - custom-modal
 screenshots:
   - description: 'WoltModalSheet page elements'
-    path: doc/bottom_sheet_elements.jpg
+    path: doc/bottom_sheet_elements.jpeg
   - description: 'WoltModalSheet page layers'
     path: doc/modal_sheet_page.png
   - description: 'Experience multi-page navigation in WoltModalSheet.'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ screenshots:
 
 environment:
   sdk: '>=3.0.6 <4.0.0'
-  flutter: '>=3.13.0'
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - custom-modal
 screenshots:
   - description: 'WoltModalSheet page elements'
-    path: doc/bottom_sheet_elements.jpeg
+    path: doc/bottom_sheet_elements.jpg
   - description: 'WoltModalSheet page layers'
     path: doc/modal_sheet_page.png
   - description: 'Experience multi-page navigation in WoltModalSheet.'

--- a/test/wolt_modal_sheet_test.dart
+++ b/test/wolt_modal_sheet_test.dart
@@ -131,7 +131,7 @@ void main() {
     'WoltModalSheet.modalTypeBuilder defaults - wide window size',
     (tester) async {
       Size viewSize = const Size(800.0, 600.0);
-      Size sheetPageSize = const Size(524.0, 86.0);
+      Size sheetPageSize = const Size(524.0, 92.0);
 
       await tester.pumpWidget(buildSheetWithShow());
 
@@ -144,11 +144,11 @@ void main() {
       expect(tester.getSize(sheetMaterial), sheetPageSize);
       expect(
         tester.getTopLeft(sheetMaterial),
-        Offset((viewSize.width / 2) - (sheetPageSize.width / 2), 257.0),
+        Offset((viewSize.width / 2) - (sheetPageSize.width / 2), 254.0),
       );
       expect(
         tester.getTopRight(sheetMaterial),
-        Offset((viewSize.width / 2) + (sheetPageSize.width / 2), 257.0),
+        Offset((viewSize.width / 2) + (sheetPageSize.width / 2), 254.0),
       );
     },
   );
@@ -190,7 +190,7 @@ void main() {
 
     expect(
       tester.getSize(sheetPageMaterialFinder(tester)),
-      const Size(800.0, 86.0),
+      const Size(800.0, 92.0),
     );
 
     // Tap to dismiss the sheet.
@@ -210,7 +210,7 @@ void main() {
 
     expect(
       tester.getSize(sheetPageMaterialFinder(tester)),
-      const Size(524.0, 86.0),
+      const Size(524.0, 92.0),
     );
 
     // Tap to dismiss the sheet.
@@ -230,7 +230,7 @@ void main() {
 
     expect(
       tester.getSize(sheetPageMaterialFinder(tester)),
-      const Size(404.0, 86.0),
+      const Size(404.0, 92.0),
     );
 
     // Tap to dismiss the sheet.
@@ -293,7 +293,7 @@ void main() {
       );
       expect(
         tester.getSize(find.byType(ColoredBox).last),
-        equals(const Size(524.0, 86.0)),
+        equals(const Size(524.0, 92.0)),
       );
     });
 


### PR DESCRIPTION
## Description

Bumps the min Flutter SDK version to 3.16.0

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

