### PR TITLE
Fix `WoltNavigationToolbar` leading constraint

### DIFF
--- a/lib/src/widgets/wolt_navigation_toolbar.dart
+++ b/lib/src/widgets/wolt_navigation_toolbar.dart
@@ -110,11 +110,10 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
     if (hasChild(_ToolbarSlot.leading)) {
       final BoxConstraints constraints = BoxConstraints(
         maxWidth: size.width,
-        minHeight:
-            size.height, // The height should be exactly the height of the bar.
         maxHeight: size.height,
       );
-      leadingWidth = layoutChild(_ToolbarSlot.leading, constraints).width;
+      final Size leadingSize = layoutChild(_ToolbarSlot.leading, constraints);
+      leadingWidth = leadingSize.width;
       final double leadingX;
       switch (textDirection) {
         case TextDirection.rtl:
@@ -124,7 +123,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
           leadingX = 0.0;
           break;
       }
-      positionChild(_ToolbarSlot.leading, Offset(leadingX, 0.0));
+      final double leadingY = (size.height - leadingSize.height) / 2.0;
+      positionChild(_ToolbarSlot.leading, Offset(leadingX, leadingY));
     }
 
     if (hasChild(_ToolbarSlot.trailing)) {

--- a/test/widgets/wolt_navigation_toolbar_test.dart
+++ b/test/widgets/wolt_navigation_toolbar_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wolt_modal_sheet/src/widgets/wolt_navigation_toolbar.dart';
+
+void main() {
+  testWidgets(
+    'Leading/Trailing widget constaints',
+    (tester) async {
+      const IconData leadingIcon = Icons.chevron_left;
+      const IconData trailingIcon = Icons.chevron_right;
+      const double iconSize = 24.0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: SizedBox(
+                height: 72.0,
+                child: WoltNavigationToolbar(
+                  leading: const ColoredBox(
+                    color: Color(0xFF00FF00),
+                    child: Icon(leadingIcon),
+                  ),
+                  trailing: Container(
+                    color: const Color(0xFFFF0000),
+                    child: const Icon(trailingIcon),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Size leadingSize = tester.getSize(find.ancestor(
+          of: find.byIcon(leadingIcon), matching: find.byType(ColoredBox)));
+      expect(leadingSize, const Size.square(iconSize));
+
+      final Size trailingSize = tester.getSize(find.ancestor(
+          of: find.byIcon(trailingIcon), matching: find.byType(ColoredBox)));
+      expect(trailingSize, const Size.square(iconSize));
+    },
+  );
+}


### PR DESCRIPTION
Fixes [leadingNavBarWidget uses more vertical space than trailingNavBarWidget](https://github.com/woltapp/wolt_modal_sheet/issues/360)

### Code Sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';
import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Builder(builder: (context) {
        return Scaffold(
          body: Center(
            child: TextButton(
              child: const Text('Open WoltModalSheet'),
              onPressed: () {
                WoltModalSheet.show(
                  context: context,
                  pageListBuilder: (context) => [
                    WoltModalSheetPage(
                      isTopBarLayerAlwaysVisible: true,
                      topBarTitle: const Text('Title'),
                      leadingNavBarWidget: Container(
                        color: Colors.blue,
                        child: const Icon(Icons.chevron_left),
                      ),
                      trailingNavBarWidget: Container(
                        color: Colors.red,
                        child: const Icon(Icons.chevron_right),
                      ),
                      child: const Padding(
                        padding: EdgeInsets.all(8.0),
                        child: Center(child: Text('Child')),
                      ),
                    ),
                  ],
                );
              },
            ),
          ), // This trailing comma makes auto-formatting nicer for build methods.
        );
      }),
    );
  }
}
```

</details>

### Before

<img width="598" alt=" " src="https://github.com/user-attachments/assets/f5b592f7-12b7-433d-bf53-2e41561e3aab" />

### After

<img width="607" alt="Screenshot 2025-01-21 at 21 29 21" src="https://github.com/user-attachments/assets/6d7fce02-f40f-4d75-a030-c1f6f20a1b3a" />

### Leading Button Splash Constraint (Before)

![Screenshot 2025-01-21 at 21 32 38](https://github.com/user-attachments/assets/eb87bfd3-301f-4e6f-a72e-72adeb4eb04c)

### Leading Button Splash Constraint (After)

![Screenshot 2025-01-21 at 21 33 59](https://github.com/user-attachments/assets/459208f3-7a02-4b67-8b2f-4336673e8a0d)


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

