### PR TITLE
FIX: More like a workaround for issue https://github.com/woltapp/wolt…

### DIFF
--- a/lib/src/content/components/paginating_group/main_content_animated_builder.dart
+++ b/lib/src/content/components/paginating_group/main_content_animated_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/content/components/paginating_group/wolt_modal_sheet_page_transition_state.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+import 'package:wolt_modal_sheet/src/widgets/pixel_slide_transition.dart';
 
 class MainContentAnimatedBuilder extends StatefulWidget {
   final AnimationController controller;
@@ -70,7 +71,7 @@ class _MainContentAnimatedBuilderState
             opacity: pageTransitionState
                 .mainContentOpacity(controller, widget.paginationAnimationStyle)
                 .value,
-            child: SlideTransition(
+            child: PixelSlideTransition(
               position: pageTransitionState.mainContentSlidePosition(
                 controller,
                 widget.paginationAnimationStyle,

--- a/lib/src/modal_type/wolt_bottom_sheet_type.dart
+++ b/lib/src/modal_type/wolt_bottom_sheet_type.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:wolt_modal_sheet/src/widgets/pixel_slide_transition.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
 
 /// A customizable bottom sheet modal that extends [WoltModalType].
@@ -124,7 +125,7 @@ class WoltBottomSheetType extends WoltModalType {
   /// [secondaryAnimation] coordinates with the transitions of other routes.
   /// [child] is the content widget to be animated.
   ///
-  /// Returns a `SlideTransition` widget that manages the modal's entrance animation.
+  /// Returns a `PixelSlideTransition` widget that manages the modal's entrance animation.
   @override
   Widget buildTransitions(
     BuildContext context,
@@ -151,7 +152,8 @@ class WoltBottomSheetType extends WoltModalType {
       ),
     );
 
-    return SlideTransition(position: positionAnimation, child: child);
+    // Use PixelSlideTransition to avoid RenderFractionalTranslation layout asserts
+    return PixelSlideTransition(position: positionAnimation, child: child);
   }
 
   /// Provides a way to create a new `WoltBottomSheetType` instance with modified properties.

--- a/lib/src/modal_type/wolt_dialog_type.dart
+++ b/lib/src/modal_type/wolt_dialog_type.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/utils/wolt_breakpoints.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+import 'package:wolt_modal_sheet/src/widgets/pixel_slide_transition.dart';
 
 /// A customizable dialog modal that extends [WoltModalType].
 class WoltDialogType extends WoltModalType {
@@ -150,7 +151,7 @@ class WoltDialogType extends WoltModalType {
 
     return FadeTransition(
       opacity: alphaAnimation,
-      child: SlideTransition(position: positionAnimation, child: child),
+      child: PixelSlideTransition(position: positionAnimation, child: child),
     );
   }
 

--- a/lib/src/modal_type/wolt_side_sheet_type.dart
+++ b/lib/src/modal_type/wolt_side_sheet_type.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:wolt_modal_sheet/src/utils/wolt_breakpoints.dart';
 import 'package:wolt_modal_sheet/wolt_modal_sheet.dart';
+import 'package:wolt_modal_sheet/src/widgets/pixel_slide_transition.dart';
 
 /// A customizable side sheet modal that extends [WoltModalType].
 class WoltSideSheetType extends WoltModalType {
@@ -168,7 +169,7 @@ class WoltSideSheetType extends WoltModalType {
 
     return FadeTransition(
       opacity: alphaAnimation,
-      child: SlideTransition(position: positionAnimation, child: child),
+      child: PixelSlideTransition(position: positionAnimation, child: child),
     );
   }
 

--- a/lib/src/widgets/pixel_slide_transition.dart
+++ b/lib/src/widgets/pixel_slide_transition.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+
+/// A slide transition that uses pixel-based translation (Transform.translate)
+/// instead of FractionalTranslation, avoiding debugNeedsLayout asserts.
+class PixelSlideTransition extends StatelessWidget {
+  /// An offset animation where values represent fractional (0.0 to 1.0) positions.
+  final Animation<Offset> position;
+
+  /// The widget child to be transformed.
+  final Widget child;
+
+  const PixelSlideTransition({
+    required this.position,
+    required this.child,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return AnimatedBuilder(
+          animation: position,
+          builder: (context, child) {
+            final offset = position.value;
+            // Convert fractional offsets to pixel values
+            final dx = offset.dx * constraints.maxWidth;
+            final dy = offset.dy * constraints.maxHeight;
+            return Transform.translate(
+              offset: Offset(dx, dy),
+              transformHitTests: false,
+              child: child,
+            );
+          },
+          child: child,
+        );
+      },
+    );
+  }
+}

--- a/lib/src/wolt_modal_sheet_route.dart
+++ b/lib/src/wolt_modal_sheet_route.dart
@@ -113,12 +113,22 @@ class WoltModalSheetRoute<T> extends PageRoute<T> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    final modalType = _determineCurrentModalType(context);
-    return modalType.buildTransitions(
-      context,
-      animation,
-      secondaryAnimation,
-      child,
+    // Prevent pointer events (e.g., mouse scroll) during entrance/exit animations
+    return AnimatedBuilder(
+      animation: animation,
+      child: child,
+      builder: (context, child) {
+        final modalType = _determineCurrentModalType(context);
+        final transition = modalType.buildTransitions(
+          context,
+          animation,
+          secondaryAnimation,
+          child!,
+        );
+        final isAnimating = animation.status != AnimationStatus.completed &&
+            animation.status != AnimationStatus.dismissed;
+        return AbsorbPointer(absorbing: isAnimating, child: transition);
+      },
     );
   }
 


### PR DESCRIPTION
FIX: https://github.com/woltapp/wolt_modal_sheet/issues/374


### Summary of my and AI analysis of the Problem

1.  **The Error:** The assertion `!debugNeedsLayout` fails within `RenderFractionalTranslation.hitTestChildren`.
2.  **Meaning:** This assertion means that Flutter is attempting to perform hit testing (determining which widget is under the pointer) on a `RenderFractionalTranslation` object *while* that object has been marked as needing a layout update (`markNeedsLayout` was called) but *before* the layout update has actually been performed (`performLayout` hasn't run yet in the current frame pipeline for this object). This is not allowed because hit testing requires up-to-date layout information (size and position) to work correctly.
3.  **The Trigger:** The error specifically happens when scrolling the modal sheet content using a mouse wheel.
4.  **Likely Cause (Race Condition):**
    *   A mouse wheel scroll event occurs over the scrollable content (`ListView`) inside the modal sheet.
    *   The Flutter framework starts processing this event. This involves dispatching the pointer event down the widget tree for hit testing to find the target (`ListView`).
    *   Simultaneously (or as part of the event handling), the scroll event likely triggers a `ScrollNotification` that bubbles up from the `ListView`.
    *   The `WoltModalSheet` widget listens for these notifications to potentially react to the scroll position (e.g., maybe for subtle animations, overscroll effects, or coordinating with sheet dragging).
    *   This notification handler calls `setState` to update some state related to the sheet's position or appearance.
    *   This `setState` triggers a rebuild. During the build, widgets related to the sheet's positioning (which often involve `SlideTransition` or other animations internally using `FractionalTranslation` -> `RenderFractionalTranslation`) get updated. This marks their corresponding `RenderObject`s (like `RenderFractionalTranslation`) as needing layout (`markNeedsLayout()`).
    *   However, the *original* hit testing process for the mouse wheel event is *still ongoing* within the same frame. When the hit test reaches the now-dirty `RenderFractionalTranslation`, the assertion `!debugNeedsLayout` fails because layout hasn't happened yet for it in this frame.


### Workaround fix

To avoid this issue I for now made a workaround I can use temporarily at least. However, a real fix should involve getting rid of any out-of bounds set state calls in relation the used scroll listeners.


The temp fix is a bit of hack, every usage of the Flutter `SlideTransition` (which under the hood is a `FractionalTranslation`) was replaced with a simple custom pixel‑based `Transform.translate` widget called `PixelSlideTransition`. That completely removes the underlying `FractionalTranslation` hit‑test logic that was tripping the `“!debugNeedsLayout”` assertion when we spin the mouse wheel.

I also wrapped our route’s entrance/exit transition in an `AbsorbPointer` so that no pointer events (incl. wheel scrolls) ever hit the sheet until its first layout is fully finished. Also 

throttled our TopBarFlow’s scroll listener to only call setState in the next frame (so we never mark the sheet dirty mid‑hitTest).

All of these changes combined eliminate the debugMode crash we are seeing. 

I am going to submit the changes as a PR so you can take a look at them. I don't think it is necessary a good actual actual fix to merge, but I **must** get rid of the assert **now**. And will use a temporary fork with this fix in it to do so while waiting for a better actual fix.

You may **use the PR as inspiration if you like**, but as said **I'm not expecting it to be merged**, you can of course if you so like, but I **think finding and fixing the actual cause** would be **better**.

A proper fix should probably prefer getting rid of all out-of bounds `setState` calls in relation the used scroll listeners.

I tried the fix with the demo issue and also with the package bundled `playground` example. Worked for both cases.

