### PR TITLE
Fix user provided scroll controllers not being managed correctly

### DIFF
--- a/lib/src/content/wolt_modal_sheet_animated_switcher.dart
+++ b/lib/src/content/wolt_modal_sheet_animated_switcher.dart
@@ -94,7 +94,7 @@ class _WoltModalSheetAnimatedSwitcherState
     _resetGlobalKeys();
     _resetScrollPositions();
     _resetScrollControllers();
-    _subscribeToCurrentPageScrollPositionChanges();
+    _subscribeToPageScrollPositionChanges();
   }
 
   void _resetGlobalKeys() {
@@ -116,18 +116,18 @@ class _WoltModalSheetAnimatedSwitcherState
     _scrollControllers.clear();
     _scrollControllers = [
       for (int i = 0; i < _pagesCount; i++)
-        (_page.scrollController ??
+        (widget.pages[i].scrollController ??
             ScrollController(initialScrollOffset: _scrollPositions[i].value)),
     ];
   }
 
-  void _subscribeToCurrentPageScrollPositionChanges() {
-    for (final scrollController in _scrollControllers) {
+  void _subscribeToPageScrollPositionChanges() {
+    for (int i = 0; i < _scrollControllers.length; i++) {
+      final scrollController = _scrollControllers[i];
+      final notifier = _scrollPositions[i];
       scrollController.addListener(() {
-        if (_currentPageScrollController.hasClients) {
-          _currentPageScrollPosition.value =
-              _currentPageScrollController.position.pixels;
-        }
+        if (!scrollController.hasClients) return;
+        notifier.value = scrollController.position.pixels;
       });
     }
   }
@@ -151,7 +151,7 @@ class _WoltModalSheetAnimatedSwitcherState
     if (!isSamePageList) {
       _resetScrollPositions();
       _resetScrollControllers();
-      _subscribeToCurrentPageScrollPositionChanges();
+      _subscribeToPageScrollPositionChanges();
       _resetGlobalKeys();
     }
 
@@ -213,8 +213,13 @@ class _WoltModalSheetAnimatedSwitcherState
   @override
   void dispose() {
     _animationController?.dispose();
-    for (final element in _scrollControllers) {
-      element.dispose();
+    for (int i = 0; i < _scrollControllers.length; i++) {
+      final element = _scrollControllers[i];
+      // We dispose every controller that's not managed by the user (i.e. not
+      // provided by the user)
+      if (widget.pages[i].scrollController == null) {
+        element.dispose();
+      }
     }
     for (final element in _scrollPositions) {
       element.dispose();


### PR DESCRIPTION
## Description
Hey,

I noticed that when passing a custom `ScrollController` to one of my sheet’s pages, it was being attached to multiple scroll views, causing an error. The issue was due to a small mistake in the code that recreates scroll controllers when pages are initialized or changed.

This PR ensures that when scroll controllers are recreated inside `WoltModalSheetAnimatedSwitcher`, user-provided controllers (if present) are correctly reused. It also avoids disposing them, as they're user managed.

Additionaly, I fixed the offset-tracking logic to properly track the offset of each controller — previously, it was repeatedly tracking the same controller's offset.

## Related Issues

I believe one of the problems mentioned in #350 may be related to this.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] The package compiles with the minimum Flutter version stated in the [pubspec.yaml](https://github.com/woltapp/wolt_modal_sheet/blob/main/pubspec.yaml#L8)


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/woltapp/wolt_modal_sheet/blob/main/CONTRIBUTING.md

